### PR TITLE
Carries the env back after the async request failed

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,8 @@ If the adapter supports it, you can make asynchronous requests by passing `respo
 Maxwell.get(url: "http://example.org", respond_to: self)
 
 receive do
-  {:maxwell_response, res} -> res.status # => 200
+  {:maxwell_response, {:ok, res}} -> res.status # => 200
+  {:maxwell_response, {:error, reason, env}} -> env # the request env
 end
 ```
 

--- a/lib/maxwell/adapter/hackney.ex
+++ b/lib/maxwell/adapter/hackney.ex
@@ -12,13 +12,15 @@ defmodule Maxwell.Adapter.Hackney do
 
   """
   def call(env) do
-    if target = env.opts[:respond_to] do
+    env = if target = env.opts[:respond_to] do
       gatherer = spawn_link fn -> receive_response(env, target, nil , nil, nil) end
       opts = env.opts |> List.keyreplace(:respond_to, 0, {:stream_to, gatherer})
-      env = %{env |opts: [:async| opts]}
+      %{env |opts: [:async| opts]}
     else
       env
     end
+
+    env
     |> send_req
     |> format_response(env)
   end

--- a/lib/maxwell/adapter/hackney.ex
+++ b/lib/maxwell/adapter/hackney.ex
@@ -60,8 +60,8 @@ defmodule Maxwell.Adapter.Hackney do
         receive_response(env, target, new_status, headers, body)
       {:hackney_response, _id, {:headers, new_headers}} ->
         receive_response(env, target, status, new_headers, body)
-      {:hackney_response, _id, {:error, _reason} = error} ->
-        send(target, {:maxwell_response, error})
+      {:hackney_response, _id, {:error, reason}} ->
+        send(target, {:maxwell_response, {:error, reason, env}})
       {:hackney_response, _id, :done} ->
         response =
           {:ok, status, headers, body}


### PR DESCRIPTION
Just return the {:error, reason} for an async request will make the response handler lose the context(url, http method etc.) to decide the source of the error. So I make added the env as the 3rd elem of the error tuple, i.e., {:error, reason, env}

I also 
- Fixed a unrecommended usage for assigning variables in the hackey adatper
- Fixed a error in the README.md on handling async response
