### PR TITLE
Header downcase

### DIFF
--- a/lib/maxwell/adapter/adapter.ex
+++ b/lib/maxwell/adapter/adapter.ex
@@ -10,6 +10,8 @@ defmodule Maxwell.Adapter do
     quote location: :keep do
       @behaviour Maxwell.Adapter
 
+      alias Maxwell.Conn
+
       @doc false
       def call(conn) do
         case conn.req_body do

--- a/lib/maxwell/adapter/hackney.ex
+++ b/lib/maxwell/adapter/hackney.ex
@@ -40,18 +40,17 @@ if Code.ensure_loaded?(:hackney) do
 
 
     defp url_serialize(url, path, query_string) do
-      url |> Maxwell.Conn.append_query_string(path, query_string) |> to_char_list
+      url |> Maxwell.Conn.append_query_string(path, query_string)
     end
     defp header_serialize(headers) do
-      headers |> Enum.map(fn({_, origin_header}) -> origin_header end)
+      for {_, origin_header} <- headers, into: [], do: origin_header
     end
 
     defp format_response({:ok, status, headers, body}, conn) when is_binary(body) do
-      headers = headers
-      |> Enum.reduce(%{}, fn({key, value}, acc) ->
-        key = key |> to_string |> String.downcase
-        Map.put(acc, key, {key, to_string(value)})
-      end)
+      headers = for {key, value}<- headers, into: %{} do
+        down_key = key |> to_string |> String.downcase
+        {down_key, {key, to_string(value)}}
+      end
       {:ok, %{conn | status: status,
               resp_headers:  headers,
               req_body:      nil,

--- a/lib/maxwell/adapter/hackney.ex
+++ b/lib/maxwell/adapter/hackney.ex
@@ -42,13 +42,18 @@ if Code.ensure_loaded?(:hackney) do
     defp url_serialize(url, path, query_string) do
       url |> Maxwell.Conn.append_query_string(path, query_string) |> to_char_list
     end
-    defp header_serialize(header) do
-      header |> Map.to_list
+    defp header_serialize(headers) do
+      headers |> Enum.map(fn({_, origin_header}) -> origin_header end)
     end
 
     defp format_response({:ok, status, headers, body}, conn) when is_binary(body) do
+      headers = headers
+      |> Enum.reduce(%{}, fn({key, value}, acc) ->
+        key = key |> to_string |> String.downcase
+        Map.put(acc, key, {key, to_string(value)})
+      end)
       {:ok, %{conn | status: status,
-              resp_headers:  headers |> :maps.from_list,
+              resp_headers:  headers,
               req_body:      nil,
               state:         :sent,
               resp_body:     body}}

--- a/lib/maxwell/adapter/hackney.ex
+++ b/lib/maxwell/adapter/hackney.ex
@@ -1,19 +1,21 @@
 if Code.ensure_loaded?(:hackney) do
   defmodule Maxwell.Adapter.Hackney do
-    use Maxwell.Adapter
     @moduledoc  """
     [`hackney`](https://github.com/benoitc/hackney) adapter
     """
+
+    use Maxwell.Adapter
 
     @doc """
     * `conn` - `%Maxwell.Conn{}`
 
     Returns `{:ok, %Maxwell.Conn{}}` or `{:error, reason_term, %Maxwell.Conn{}}`.
     """
+
     def send_direct(conn) do
-      %Maxwell.Conn{url: url, req_headers: req_headers,
-                    path: path,method: method, query_string: query_string,
-                    opts: opts, req_body: req_body} = conn
+      %Conn{url: url, req_headers: req_headers,
+            path: path,method: method, query_string: query_string,
+            opts: opts, req_body: req_body} = conn
       url = url_serialize(url, path, query_string)
       req_headers = header_serialize(req_headers)
       result = :hackney.request(method, url, req_headers, req_body || "", opts)
@@ -25,9 +27,9 @@ if Code.ensure_loaded?(:hackney) do
     def send_file(conn), do: send_direct(conn)
 
     def send_stream(conn) do
-      %Maxwell.Conn{url: url, req_headers: req_headers,
-                    path: path,method: method, query_string: query_string,
-                    opts: opts, req_body: req_body} = conn
+      %Conn{url: url, req_headers: req_headers,
+            path: path,method: method, query_string: query_string,
+            opts: opts, req_body: req_body} = conn
       url = url_serialize(url, path, query_string)
       req_headers = header_serialize(req_headers)
       with {:ok, ref} <- :hackney.request(method, url, req_headers, :stream, opts) do
@@ -40,10 +42,10 @@ if Code.ensure_loaded?(:hackney) do
 
 
     defp url_serialize(url, path, query_string) do
-      url |> Maxwell.Conn.append_query_string(path, query_string)
+      url |> Conn.append_query_string(path, query_string)
     end
     defp header_serialize(headers) do
-      for {_, origin_header} <- headers, into: [], do: origin_header
+      headers |> Enum.map(&elem(&1, 1))
     end
 
     defp format_response({:ok, status, headers, body}, conn) when is_binary(body) do

--- a/lib/maxwell/adapter/ibrowse.ex
+++ b/lib/maxwell/adapter/ibrowse.ex
@@ -100,16 +100,12 @@ if Code.ensure_loaded?(:ibrowse) do
     defp multipart_encode(headers, multiparts) do
       boundary = Maxwell.Multipart.new_boundary
       body = {&multipart_body/1, {:start, boundary, multiparts}}
-      headers =
-        case Map.has_key?(headers, "content-type") do
-          true ->
-            headers
-          false ->
-            len = Maxwell.Multipart.len_mp_stream(boundary, multiparts)
-            headers
-            |> Map.put("content-type", {"content-type", "multipart/form-data; boundary=#{boundary}"})
-            |> Map.put("content-length", {"content-length",len})
-        end
+
+      len = Maxwell.Multipart.len_mp_stream(boundary, multiparts)
+      headers = headers
+      |> Map.put("content-type", {"content-type", "multipart/form-data; boundary=#{boundary}"})
+      |> Map.put("content-length", {"content-length",len})
+
       {headers, body}
     end
 

--- a/lib/maxwell/adapter/ibrowse.ex
+++ b/lib/maxwell/adapter/ibrowse.ex
@@ -4,7 +4,7 @@ if Code.ensure_loaded?(:ibrowse) do
     [`ibrowse`](https://github.com/cmullaparthi/ibrowse) adapter
     """
 
-    @chunk_size 5*1024*1024
+    @chunk_size 4*1024*1024
     use Maxwell.Adapter
 
     @doc """

--- a/lib/maxwell/adapter/ibrowse.ex
+++ b/lib/maxwell/adapter/ibrowse.ex
@@ -76,14 +76,19 @@ if Code.ensure_loaded?(:ibrowse) do
     defp url_serialize(url, path, query_string) do
       url |> Maxwell.Conn.append_query_string(path, query_string) |> to_char_list
     end
-    defp header_serialize(header) do
-      header |> Map.to_list
+    defp header_serialize(headers) do
+      headers |> Enum.map(fn({_, origin_header}) -> origin_header end)
     end
 
     defp format_response({:ok, status, headers, body}, conn) do
       {status, _} = status |> to_string |> Integer.parse
+      headers = headers
+      |> Enum.reduce(%{}, fn({key, value}, acc) ->
+        key = key |> to_string |> String.downcase
+        Map.put(acc, key, {key, to_string(value)})
+      end)
       {:ok, %{conn |status:   status,
-              resp_headers:  headers |> :maps.from_list,
+              resp_headers:  headers,
               resp_body:     body,
               state:         :sent,
               req_body:      nil}

--- a/lib/maxwell/conn.ex
+++ b/lib/maxwell/conn.ex
@@ -140,8 +140,8 @@ defmodule Maxwell.Conn do
   Add query string to `conn.query_string`.
 
   * `conn` - `%Conn{}`
-  * `query_key` - query key, for example `"name"`.
-  * `query_value` - query value, for example `"lucy"`.
+  * `key` - query key, for example `"name"`.
+  * `value` - query value, for example `"lucy"`.
 
   ### Examples
 

--- a/lib/maxwell/conn.ex
+++ b/lib/maxwell/conn.ex
@@ -265,8 +265,7 @@ defmodule Maxwell.Conn do
   def get_resp_header(conn, key \\ nil)
   def get_resp_header(%Conn{state: :unsent}, _key), do: raise NotSentError
   def get_resp_header(%Conn{resp_headers: headers}, nil) do
-    IO.inspect {:xxxxx, headers}
-    Enum.reduce(headers, %{}, fn({_, {key, value}}, acc) -> Map.put(acc, key, value) end)
+    for {_, origin_header} <- headers, into: %{}, do: origin_header
   end
   def get_resp_header(%Conn{resp_headers: headers}, key), do: headers[String.downcase(key)]
 

--- a/lib/maxwell/middleware/header.ex
+++ b/lib/maxwell/middleware/header.ex
@@ -17,9 +17,12 @@ defmodule Maxwell.Middleware.Headers do
 
   use Maxwell.Middleware
 
+  def init(headers) do
+    Enum.reduce(headers, %{}, fn({key, value}, acc) -> Map.put(acc, String.downcase(key), {key, value}) end)
+  end
+
   def request(conn, req_headers) do
-    headers = Map.merge(req_headers, conn.req_headers)
-    %{conn | req_headers: headers}
+    %{conn| req_headers: Map.merge(req_headers, conn.req_headers)}
   end
 end
 

--- a/lib/maxwell/middleware/header.ex
+++ b/lib/maxwell/middleware/header.ex
@@ -18,7 +18,7 @@ defmodule Maxwell.Middleware.Headers do
   use Maxwell.Middleware
 
   def init(headers) do
-    Enum.reduce(headers, %{}, fn({key, value}, acc) -> Map.put(acc, String.downcase(key), {key, value}) end)
+    for {key, value} <- headers, into: %{}, do: {String.downcase(key), {key, value}}
   end
 
   def request(conn, req_headers) do

--- a/lib/maxwell/middleware/header.ex
+++ b/lib/maxwell/middleware/header.ex
@@ -16,13 +16,22 @@ defmodule Maxwell.Middleware.Headers do
   """
 
   use Maxwell.Middleware
+  alias Maxwell.Conn
 
   def init(headers) do
-    for {key, value} <- headers, into: %{}, do: {String.downcase(key), {key, value}}
+    check_headers(headers)
+    Conn.put_req_header(%Conn{}, headers) |> Map.get(:req_headers)
   end
 
   def request(conn, req_headers) do
     %{conn| req_headers: Map.merge(req_headers, conn.req_headers)}
+  end
+
+  defp check_headers(headers) do
+    case Enum.all?(headers, fn({key, _value}) -> is_binary(key) end) do
+      true -> :ok
+      false -> raise(ArgumentError, "Headers_map key only accpect string but got: #{inspect headers}");
+    end
   end
 end
 

--- a/lib/maxwell/multipart.ex
+++ b/lib/maxwell/multipart.ex
@@ -4,23 +4,38 @@ defmodule Maxwell.Multipart do
   """
   @eof_size 2
   @doc """
-  Receives lists list's member format:
+  multipart form encode.
 
-  1. `{:file, path}`
-  2. `{:file, path, extra_headers}`
-  3. `{:file, path, disposition, extra_headers}`
-  4. `{:mp_mixed, name, mixed_boundary}`
-  5. `{:mp_mixed_eof, mixed_boundary}`
-  6. `{name, bin_data}`
-  7. `{name, bin_data, extra_headers}`
-  8. `{name, bin_data, disposition, extra_headers}`
+      * `parts` - receives lists list's member format:
+
+           1. `{:file, path}`
+           2. `{:file, path, extra_headers}`
+           3. `{:file, path, disposition, extra_headers}`
+           4. `{:mp_mixed, name, mixed_boundary}`
+           5. `{:mp_mixed_eof, mixed_boundary}`
+           6. `{name, bin_data}`
+           7. `{name, bin_data, extra_headers}`
+           8. `{name, bin_data, disposition, extra_headers}`
 
   Returns `{body_binary, size}`
 
   """
   def encode_form(parts), do: encode_form(new_boundary, parts)
   @doc """
-  See `encode_form/1`
+  multipart form encode.
+
+     * `boundary` - multipart boundary.
+     * `parts` - receives lists list's member format:
+
+          1. `{:file, path}`
+          2. `{:file, path, extra_headers}`
+          3. `{:file, path, disposition, extra_headers}`
+          4. `{:mp_mixed, name, mixed_boundary}`
+          5. `{:mp_mixed_eof, mixed_boundary}`
+          6. `{name, bin_data}`
+          7. `{name, bin_data, extra_headers}`
+          8. `{name, bin_data, disposition, extra_headers}`
+
   """
   def encode_form(boundary, parts)when is_list(parts) do
     encode_form(parts, boundary, "", 0)
@@ -40,7 +55,8 @@ defmodule Maxwell.Multipart do
   @doc """
   Get the size of a mp stream. Useful to calculate the content-length of a full multipart stream and send it as an identity
 
-  Receives parameter as `Maxwell.Multipart.encode`
+      * `boundary` - multipart boundary
+      * `parts` - see `Maxwell.Multipart.encode_form`.
 
   Return stream size(integer)
   """

--- a/test/maxwell/adapter/adapter_test.exs
+++ b/test/maxwell/adapter/adapter_test.exs
@@ -8,7 +8,7 @@ defmodule MaxwellAdapterTest do
     use Maxwell.Adapter
     def send_direct(conn = %Conn{status: nil}) do
       {:ok, %{conn|status: 200,
-              resp_headers: %{"Content-Type" => "text/plain"},
+              resp_headers: %{"content-type" => {"Content-Type", "text/plain"}},
               resp_body: "testbody",
               state: :sent}}
     end
@@ -35,7 +35,7 @@ defmodule MaxwellAdapterTest do
   test "return resp content-type header" do
     {:ok, conn} = Client.get()
     assert conn |> get_resp_header == %{"Content-Type" => "text/plain"}
-    assert conn |> get_resp_header("Content-Type") == "text/plain"
+    assert conn |> get_resp_header("Content-Type") == {"Content-Type", "text/plain"}
   end
 
   test "return resp_body" do

--- a/test/maxwell/adapter/ibrowse_test.exs
+++ b/test/maxwell/adapter/ibrowse_test.exs
@@ -72,6 +72,14 @@ defmodule Maxwell.IbrowseTest do
       |> Client.post!
     end
 
+    def file_test(filepath, content_type) do
+      "/post"
+      |> put_path
+      |> put_req_body({:file, filepath})
+      |> put_req_header("content-type", content_type)
+      |> Client.post!
+    end
+
     def stream_test() do
       "/post"
       |> put_path
@@ -109,8 +117,13 @@ defmodule Maxwell.IbrowseTest do
     assert get_resp_body(conn, "files") == %{"file" => "#!/usr/bin/env bash\necho \"test multipart file\"\n"}
   end
 
-  test "send file" do
+  test "send file without content-type" do
     conn = Client.file_test("test/maxwell/multipart_test_file.sh")
+    assert get_resp_body(conn, "data") == "#!/usr/bin/env bash\necho \"test multipart file\"\n"
+  end
+
+  test "send file with content-type" do
+    conn = Client.file_test("test/maxwell/multipart_test_file.sh", "application/x-sh")
     assert get_resp_body(conn, "data") == "#!/usr/bin/env bash\necho \"test multipart file\"\n"
   end
 

--- a/test/maxwell/conn_test.exs
+++ b/test/maxwell/conn_test.exs
@@ -39,6 +39,9 @@ defmodule ConnTest do
     assert put_req_header(%{"cache-control" => "no-cache", "ETag" => "rFjdsDtv2qxk7K1CwG4VMlF836E="})
     == %Conn{state: :unsent, req_headers: %{"cache-control" => {"cache-control", "no-cache"},
                                             "etag" => {"ETag", "rFjdsDtv2qxk7K1CwG4VMlF836E="}}}
+    assert put_req_header(%{"cache-control" => {"cache-control", "no-cache"}, "ETag" => "rFjdsDtv2qxk7K1CwG4VMlF836E="})
+    == %Conn{state: :unsent, req_headers: %{"cache-control" => {"cache-control", "no-cache"},
+                                            "etag" => {"ETag", "rFjdsDtv2qxk7K1CwG4VMlF836E="}}}
 
     assert_raise AlreadySentError, "the request was already sent", fn ->
       put_req_header(%Conn{state: :sent}, %{"cache-control" => "no-cache"})

--- a/test/maxwell/conn_test.exs
+++ b/test/maxwell/conn_test.exs
@@ -35,9 +35,10 @@ defmodule ConnTest do
   test "put_req_header/2 put_req_header/3 test" do
     assert put_req_header(%Conn{}, "cache-control", "no-cache")
     assert put_req_header(%Conn{state: :unsent}, "cache-control", "no-cache")
-    == %Conn{state: :unsent, req_headers: %{"cache-control" => "no-cache"}}
+    == %Conn{state: :unsent, req_headers: %{"cache-control" => {"cache-control", "no-cache"}}}
     assert put_req_header(%{"cache-control" => "no-cache", "ETag" => "rFjdsDtv2qxk7K1CwG4VMlF836E="})
-    == %Conn{state: :unsent, req_headers: %{"cache-control" => "no-cache", "ETag" => "rFjdsDtv2qxk7K1CwG4VMlF836E="}}
+    == %Conn{state: :unsent, req_headers: %{"cache-control" => {"cache-control", "no-cache"},
+                                            "etag" => {"ETag", "rFjdsDtv2qxk7K1CwG4VMlF836E="}}}
 
     assert_raise AlreadySentError, "the request was already sent", fn ->
       put_req_header(%Conn{state: :sent}, %{"cache-control" => "no-cache"})
@@ -74,10 +75,10 @@ defmodule ConnTest do
   end
 
   test "get_resp_header/2 get_resp_header/3 test" do
-    assert get_resp_header(%Conn{state: :sent, resp_headers: %{"Server" => "Microsoft-IIS/8.5"}})
+    assert get_resp_header(%Conn{state: :sent, resp_headers: %{"server" => {"Server", "Microsoft-IIS/8.5"}}})
     == %{"Server" => "Microsoft-IIS/8.5"}
-    assert get_resp_header(%Conn{state: :sent, resp_headers: %{"Server" => "Microsoft-IIS/8.5"}}, "Server")
-    == "Microsoft-IIS/8.5"
+    assert get_resp_header(%Conn{state: :sent, resp_headers: %{"server" => {"Server", "Microsoft-IIS/8.5"}}}, "Server")
+    == {"Server", "Microsoft-IIS/8.5"}
     assert_raise NotSentError, "the request was not sent yet", fn ->
       get_resp_header(%Conn{state: :unsent}, "Server")
     end

--- a/test/maxwell/middleware/header_test.exs
+++ b/test/maxwell/middleware/header_test.exs
@@ -7,15 +7,15 @@ defmodule HeaderTest do
     conn =
       request(Maxwell.Middleware.Headers,
         %Conn{req_headers: %{}},
-        %{"Content-Type" => "text/plain"})
-    assert conn.req_headers == %{"Content-Type" => "text/plain"}
+        %{"content-type" => {"Content-Type", "text/plain"}})
+    assert conn.req_headers == %{"content-type" => {"Content-Type", "text/plain"}}
   end
 
   test "Replace Middleware Headers" do
     conn = request(Maxwell.Middleware.Headers,
-      %{req_headers: %{"Content-Type" => "application/json"}},
-      %{"Content-Type" => "text/plain"})
-    assert conn.req_headers == %{"Content-Type" => "application/json"}
+      %Conn{req_headers: %{"content-type" => {"Content-Type", "application/json"}}},
+      %{"content-type" => {"Content-Type", "text/plain"}})
+    assert conn.req_headers == %{"content-type" => {"Content-Type", "application/json"}}
   end
 
 end

--- a/test/maxwell/middleware/header_test.exs
+++ b/test/maxwell/middleware/header_test.exs
@@ -18,5 +18,15 @@ defmodule HeaderTest do
     assert conn.req_headers == %{"content-type" => {"Content-Type", "application/json"}}
   end
 
+  test "header key is not string" do
+    assert_raise ArgumentError, "Headers_map key only accpect string but got: %{key: \"value\"}", fn ->
+      defmodule TAtom111 do
+        use Maxwell.Builder, [:get, :post]
+        middleware Maxwell.Middleware.Headers, %{:key => "value"}
+      end
+      raise "ok"
+    end
+  end
+
 end
 

--- a/test/maxwell/middleware/json_test.exs
+++ b/test/maxwell/middleware/json_test.exs
@@ -7,25 +7,32 @@ defmodule JsonTest do
       case conn.path do
         "/decode" ->
           {:ok,
-           %{conn| status: 200, resp_headers: %{"Content-Type" => "application/json"}, resp_body: "{\"value\": 123}"}}
+           %{conn| status: 200, resp_headers: %{"content-type" => {"Content-Type", "application/json"}},
+             resp_body: "{\"value\": 123}"}}
         "/decode_error" ->
           {:ok,
-           %{conn| status: 200, resp_headers: %{"Content-Type" => "application/json"}, resp_body: "\"123"}}
+           %{conn| status: 200, resp_headers: %{"content-type" => {"Content-Type", "application/json"}},
+             resp_body: "\"123"}}
         "/encode" ->
           {:ok,
-           %{conn| status: 200, resp_headers: %{"Content-Type" => "application/json"}, resp_body: conn.req_body |> String.replace("foo", "baz")}}
+           %{conn| status: 200, resp_headers: %{"content-type" => {"Content-Type", "application/json"}},
+             resp_body: conn.req_body |> String.replace("foo", "baz")}}
         "/empty" ->
           {:ok,
-           %{conn| status: 200, resp_headers: %{"Content-Type" => "application/json"}, resp_body: nil}}
+           %{conn| status: 200, resp_headers: %{"content-type" => {"Content-Type", "application/json"}},
+             resp_body: nil}}
         "/tuple" ->
           {:ok,
-           %{conn| status: 200, resp_headers: %{"Content-Type" => "application/json"}, resp_body: {:key, :value}}}
+           %{conn| status: 200, resp_headers: %{"content-type" => {"Content-Type", "application/json"}},
+             resp_body: {:key, :value}}}
         "/invalid-content-type" ->
           {:ok,
-           %{conn| status: 200, resp_headers: %{"Content-Type" => "text/plain"}, resp_body: "hello"}}
+           %{conn| status: 200, resp_headers: %{"content-type" => {"Content-Type", "text/plain"}},
+             resp_body: "hello"}}
         "/use-defined-content-type" ->
           {:ok,
-           %{conn| status: 200, resp_headers: %{"Content-Type" => "text/html"}, resp_body: "{\"value\": 124}"}};
+           %{conn| status: 200, resp_headers: %{"content-type" => {"Content-Type", "text/html"}},
+             resp_body: "{\"value\": 124}"}};
         "/not_found_404" ->
           {:ok, %{conn| status: 404, resp_body: "404 Not Found"}}
         "/redirection_301" ->
@@ -58,7 +65,7 @@ defmodule JsonTest do
     assert conn == %Conn{method: :get, opts: [connect_timeout: 3000],
                          path: "/decode_error", query_string: %{},
                          req_body: nil, req_headers: %{},
-                         resp_body: "\"123", resp_headers: %{"Content-Type" => "application/json"},
+                         resp_body: "\"123", resp_headers: %{"content-type" => {"Content-Type", "application/json"}},
                          state: :sent, status: 200, url: ""}
   end
 
@@ -131,7 +138,7 @@ defmodule ModuleAdapter2 do
   def call(conn) do
     {:ok, %{conn|status: 200,
             state: :sent,
-            resp_headers: %{"Content-Type" => "text/javascript"},
+            resp_headers: %{"content-type" => {"Content-Type","text/javascript"}},
             resp_body: "{\"value\": 124}"}}
   end
 end

--- a/test/maxwell/middleware/middleware_test.exs
+++ b/test/maxwell/middleware/middleware_test.exs
@@ -6,9 +6,11 @@ defmodule MiddlewareTest do
       conn = %{conn| state: :sent}
       body = unless conn.req_body, do: %{}, else: Poison.decode!(conn.req_body)
       if Map.equal?(body, %{"key2" => 101, "key1" => 201}) do
-        {:ok, %{conn| status: 200, resp_headers: %{"Content-Type" => "application/json"}, resp_body: "{\"key2\":101,\"key1\":201}"}}
+        {:ok, %{conn| status: 200, resp_headers: %{"content-type" => {"Content-Type", "application/json"}},
+                resp_body: "{\"key2\":101,\"key1\":201}"}}
       else
-        {:ok, %{conn| status: 200, resp_headers: %{"Content-Type" => "application/json"}, resp_body: "{\"key2\":2,\"key1\":1}"}}
+          {:ok, %{conn| status: 200, resp_headers: %{"content-type" => {"Content-Type", "application/json"}},
+                  resp_body: "{\"key2\":2,\"key1\":1}"}}
       end
     end
   end
@@ -36,7 +38,7 @@ defmodule MiddlewareTest do
 
   test "make use of headers" do
     assert Client.get!|> get_resp_header == %{"Content-Type" => "application/json"}
-    assert Client.get!|> get_resp_header("Content-Type") == "application/json"
+    assert Client.get!|> get_resp_header("Content-Type") == {"Content-Type", "application/json"}
   end
 
   test "make use of endeodejson" do


### PR DESCRIPTION
```ex
%Maxwell.Conn{
req_headers => %{"downcase_key" => {"original_key", value}},
resp_headers => %{"downcase_key1" => {"original_key1", value1}}
}

# conn req_header %{"key_downcase" => {key, value}, "key1_downcase" => {key1, value1}}
Maxwell.Conn.put_req_header(conn, %{key => value, key1 => value1})

# %{key => value,  key1 => value1}
Maxwell.Conn.get_resp_header(%Maxwell.Conn{resp_headers => 
    %{"key_downcase" => {key, value}, "key1_downcase" => {key1, value1}})

# {key1, value1}
Maxwell.Conn.get_resp_header(
  %Maxwell.Conn{resp_headers => %{"key_downcase" => {key, value}, 
    "key1_downcase" => {key1, value1}},
 key1_downcase)
```