### PR TITLE
Implement fuse middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ rel/example_project
 ### Elixir template
 /_build
 /deps
+/cover
 erl_crash.dump
 *.ez
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -21,6 +21,8 @@ use Mix.Config
 #     config :logger, level: :info
 config :maxwell,
   default_adapter: Maxwell.Adapter.Ibrowse
+config :sasl,
+  errlog_type: :error
 #
 # It is also possible to import configuration files, relative to this
 # directory. For example, you can emulate configuration per environment

--- a/lib/maxwell/adapter/httpc.ex
+++ b/lib/maxwell/adapter/httpc.ex
@@ -91,6 +91,19 @@ defmodule Maxwell.Adapter.Httpc do
              req_body:      nil}
   end
   ## todo {:ok, request_id}
+
+  # normalize :econnrefused for the Retry/Fuse middleware
+  defp format_response({:error, {:failed_connect, info} = err}, conn) do
+    conn = %{conn | state: :error}
+    case List.keyfind(info, :inet, 0) do
+      {:inet, _, :econnrefused} ->
+         {:error, :econnrefused, conn}
+      {:inet, _, reason} ->
+         {:error, reason, conn}
+      _ ->
+         {:error, err, conn}
+    end
+  end
   defp format_response({:error, reason}, conn) do
     {:error, reason, %{conn | state: :error}}
   end

--- a/lib/maxwell/adapter/ibrowse.ex
+++ b/lib/maxwell/adapter/ibrowse.ex
@@ -68,6 +68,12 @@ if Code.ensure_loaded?(:ibrowse) do
                state:         :sent,
                req_body:      nil}
     end
+    defp format_response({:error, {:conn_failed, {:error, :econnrefused}}}, conn) do
+      {:error, :econnrefused, %{conn | state: :error}}
+    end
+    defp format_response({:error, {:conn_failed, {:error, reason}}}, conn) do
+      {:error, reason, %{conn | state: :error}}
+    end
     defp format_response({:error, reason}, conn) do
       {:error, reason, %{conn | state: :error}}
     end

--- a/lib/maxwell/middleware/fuse.ex
+++ b/lib/maxwell/middleware/fuse.ex
@@ -45,7 +45,10 @@ defmodule Maxwell.Middleware.Fuse do
         :fuse.install(name, Keyword.get(opts, :fuse_opts))
         run(conn, next, name)
     end
-    response(conn, opts)
+    case conn do
+      %Maxwell.Conn{} = conn -> response(conn, opts)
+      err -> err
+    end
   end
 
   defp run(conn, next, name) do

--- a/lib/maxwell/middleware/fuse.ex
+++ b/lib/maxwell/middleware/fuse.ex
@@ -1,0 +1,61 @@
+if Code.ensure_loaded?(:fuse) do
+defmodule Maxwell.Middleware.Fuse do
+  @moduledoc """
+  A circuit breaker middleware which uses [fuse](https://github.com/jlouis/fuse) under the covers.
+
+  To use this middleware, you will need to add `{:fuse, "~> 2.4"}` to your dependencies, and
+  the `:fuse` application to your applications list in `mix.exs`.
+
+  Example:
+
+      defmodule CircuitBreakerClient do
+        use Maxwell.Builder
+
+        middleware Maxwell.Middleware.Fuse,
+          name: __MODULE__,
+          fuse_opts: {{:standard, 2, 10_000}, {:reset, 60_000}}
+      end
+
+  Options:
+
+      - `:name` - The name of the fuse, required
+      - `:fuse_opts` - Options to pass along to `fuse`. See `fuse` docs for more information.
+  """
+  use Maxwell.Middleware
+
+  # These options were borrowed from http://blog.rokkincat.com/circuit-breakers-in-elixir/
+  # You should tweak them for your use case, as these defaults are likely unsuitable.
+  @default_fuse_opts {{:standard, 2, 10_000}, {:reset, 60_000}}
+
+  @default_opts [fuse_opts: @default_fuse_opts]
+
+  def init(opts) do
+    _name = Keyword.fetch!(opts, :name)
+    Keyword.merge(@default_opts, opts)
+  end
+
+  def call(conn, next, opts) do
+    name = Keyword.get(opts, :name)
+    conn = case :fuse.ask(name, :sync) do
+      :ok ->
+        run(conn, next, name)
+      :blown ->
+        {:error, :econnrefused, conn}
+      {:error, :not_found} ->
+        :fuse.install(name, Keyword.get(opts, :fuse_opts))
+        run(conn, next, name)
+    end
+    response(conn, opts)
+  end
+
+  defp run(conn, next, name) do
+    case next.(conn) do
+      {:error, _reason, _conn} = err ->
+        :fuse.melt(name)
+        err
+      res ->
+        res
+    end
+  end
+end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -35,6 +35,7 @@ defmodule Maxwell.Mixfile do
       {:poison, "~> 2.1 or ~> 3.0", optional: true},
       {:ibrowse, "~> 4.2", optional: true},
       {:hackney, "~> 1.6", optional: true},
+      {:fuse, "~> 2.4", optional: true},
       {:excoveralls, "~> 0.5.1", only: :test},
       {:ex_doc, ">= 0.11.4", only: [:dev]},
       {:markdown, github: "devinus/markdown", only: [:dev]},

--- a/mix.lock
+++ b/mix.lock
@@ -6,6 +6,7 @@
   "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "excoveralls": {:hex, :excoveralls, "0.5.7", "5d26e4a7cdf08294217594a1b0643636accc2ad30e984d62f1d166f70629ff50", [:mix], [{:exjsx, "~> 3.0", [hex: :exjsx, optional: false]}, {:hackney, ">= 0.12.0", [hex: :hackney, optional: false]}]},
   "exjsx": {:hex, :exjsx, "3.2.1", "1bc5bf1e4fd249104178f0885030bcd75a4526f4d2a1e976f4b428d347614f0f", [:mix], [{:jsx, "~> 2.8.0", [hex: :jsx, optional: false]}]},
+  "fuse": {:hex, :fuse, "2.4.0", "499ab65d3b1d291909973e1c25bdc55a17379fb26899f25eb68b6437a880de1b", [:make, :rebar], []},
   "hackney": {:hex, :hackney, "1.6.3", "d489d7ca2d4323e307bedc4bfe684323a7bf773ecfd77938f3ee8074e488e140", [:mix, :rebar3], [{:certifi, "0.7.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, optional: false]}]},
   "hoedown": {:git, "https://github.com/hoedown/hoedown.git", "980b9c549b4348d50b683ecee6abee470b98acda", []},
   "ibrowse": {:hex, :ibrowse, "4.2.2", "b32b5bafcc77b7277eff030ed32e1acc3f610c64e9f6aea19822abcadf681b4b", [:rebar3], []},

--- a/test/maxwell/middleware/fuse_test.exs
+++ b/test/maxwell/middleware/fuse_test.exs
@@ -7,7 +7,7 @@ defmodule FuseTest do
       send self(), :request_made
       conn = %{conn | state: :sent}
       case path do
-        "/ok" -> {:ok, %{conn | status: 200, resp_body: "ok"}}
+        "/ok" -> %{conn | status: 200, resp_body: "ok"}
         "/unavailable" -> {:error, :econnrefused, conn}
       end
     end

--- a/test/maxwell/middleware/fuse_test.exs
+++ b/test/maxwell/middleware/fuse_test.exs
@@ -1,0 +1,48 @@
+defmodule FuseTest do
+  use ExUnit.Case, async: false
+  alias Maxwell.Conn
+
+  defmodule FuseAdapter do
+    def call(%{path: path} = conn) do
+      send self(), :request_made
+      conn = %{conn | state: :sent}
+      case path do
+        "/ok" -> {:ok, %{conn | status: 200, resp_body: "ok"}}
+        "/unavailable" -> {:error, :econnrefused, conn}
+      end
+    end
+  end
+
+  defmodule Client do
+    use Maxwell.Builder
+    middleware Maxwell.Middleware.Fuse,
+      name: __MODULE__,
+      fuse_opts: {{:standard, 2, 10_000}, {:reset, 60_000}}
+    adapter FuseAdapter
+  end
+
+
+  setup do
+    {:ok, _} = Application.ensure_all_started(:fuse)
+    :fuse.reset(Client)
+    :ok
+  end
+
+  test "regular endpoint" do
+    assert Conn.put_path("/ok") |> Client.get! |> Conn.get_resp_body() == "ok"
+  end
+
+  test "unavailable endpoint" do
+    assert_raise Maxwell.Error, fn -> Conn.put_path("/unavailable") |> Client.get! end
+    assert_receive :request_made
+    assert_raise Maxwell.Error, fn -> Conn.put_path("/unavailable") |> Client.get! end
+    assert_receive :request_made
+    assert_raise Maxwell.Error, fn -> Conn.put_path("/unavailable") |> Client.get! end
+    assert_receive :request_made
+
+    assert_raise Maxwell.Error, fn -> Conn.put_path("/unavailable") |> Client.get! end
+    refute_receive :request_made
+    assert_raise Maxwell.Error, fn -> Conn.put_path("/unavailable") |> Client.get! end
+    refute_receive :request_made
+  end
+end


### PR DESCRIPTION
Implements the Fuse middleware from Tesla, a few small changes from how it was implemented there so that it plays nice with the Retry middleware (i.e. if the circuit breaker melts, the retry will automatically attempt again after the delay - if the Retry middleware is being used and comes before the Fuse middleware that is).