### PR TITLE
Fix broken logger middleware

### DIFF
--- a/lib/maxwell/middleware/logger.ex
+++ b/lib/maxwell/middleware/logger.ex
@@ -29,7 +29,7 @@ defmodule Maxwell.Middleware.Logger do
       {:error, reason, _conn} ->
         error_reason = to_string(:io_lib.format("~p", [reason]))
         Logger.log(level, "#{method} #{request_env.url}>> #{IO.ANSI.red}ERROR: " <> error_reason)
-      {:ok, response_conn} ->
+      response_conn ->
         finish_time = :os.timestamp()
         duration = :timer.now_diff(finish_time, start_time)
         duration_ms = :io_lib.format("~.3f", [duration / 10_000])

--- a/test/maxwell/middleware/logger_test.exs
+++ b/test/maxwell/middleware/logger_test.exs
@@ -18,10 +18,10 @@ defmodule LoggerTest do
     conn = %Conn{method: :get, url: "http://example.com", status: 200}
     outputstr = capture_log fn ->
       Maxwell.Middleware.Logger.call(conn,fn(x) ->{:error, "bad request", %{x| status: 400}} end, :info) end
-    output301 = capture_log fn -> Maxwell.Middleware.Logger.call(conn, fn(x) -> {:ok, %{x| status: 301}} end, :info) end
-    output404 = capture_log fn -> Maxwell.Middleware.Logger.call(conn, fn(x) -> {:ok, %{x| status: 404}} end, :info) end
-    output500 = capture_log fn -> Maxwell.Middleware.Logger.call(conn, fn(x) -> {:ok, %{x| status: 500}} end, :info) end
-    outputok  = capture_log fn -> Maxwell.Middleware.Logger.call(conn, fn(x) -> {:ok, x} end, :info) end
+    output301 = capture_log fn -> Maxwell.Middleware.Logger.call(conn, fn(x) -> %{x| status: 301} end, :info) end
+    output404 = capture_log fn -> Maxwell.Middleware.Logger.call(conn, fn(x) -> %{x| status: 404} end, :info) end
+    output500 = capture_log fn -> Maxwell.Middleware.Logger.call(conn, fn(x) -> %{x| status: 500} end, :info) end
+    outputok  = capture_log fn -> Maxwell.Middleware.Logger.call(conn, fn(x) -> x end, :info) end
     assert outputstr =~ ~r"\e\[22m\n\d+:\d+:\d+.\d+ \[info\]  GET http://example.com>> \e\[31mERROR: <<\"bad request\">>\n\e\[0m"
 
     assert output301 =~ ~r"\e\[22m\n\d+:\d+:\d+.\d+ \[info\]  get http://example.com <<<\e\[33m301\(\d+.\d+ms\)\e\[0m\n%Maxwell.Conn\{method: :get, opts: \[\], path: \"\", query_string: \%\{\}, req_body: nil, req_headers: \%\{\}, resp_body: \"\", resp_headers: \%\{\}, state: :unsent, status: 301, url: \"http://example.com\"\}\n\e\[0m"


### PR DESCRIPTION
The logger middleware was returning `{:ok, Maxwell.Conn.t}`, even though middlewares are supposed to return just `Maxwell.Conn.t` - the tests were wrong as well, so this slipped under the radar. I only noticed because it exploded on me when testing Maxwell in my app.