### PR TITLE
Fix internal consistency issues. See #30

### DIFF
--- a/lib/maxwell/adapter/adapter.ex
+++ b/lib/maxwell/adapter/adapter.ex
@@ -5,6 +5,11 @@ defmodule Maxwell.Adapter do
   ### Examples
   See `Maxwell.Adapter.Ibrowse`.
   """
+  @type return_t :: Maxwell.Conn.t | {:error, any, Maxwell.Conn.t}
+
+  @callback send_direct(Maxwell.Conn.t) :: return_t
+  @callback send_multipart(Maxwell.Conn.t) :: return_t
+  @callback send_file(Maxwell.Conn.t) :: return_t
 
   defmacro __using__(_opts) do
     quote location: :keep do
@@ -14,12 +19,20 @@ defmodule Maxwell.Adapter do
       alias Maxwell.Adapter.Util
 
       @doc false
+      @spec call(Conn.t) :: Conn.t | {:error, reason :: any(), Conn.t}
       def call(conn) do
-        case conn.req_body do
+        res = case conn.req_body do
           {:multipart, _} -> send_multipart(conn)
-          {:file, _} -> send_file(conn)
-          %Stream{} -> send_stream(conn)
-          _ -> send_direct(conn)
+          {:file, _}      -> send_file(conn)
+          %Stream{}       -> send_stream(conn)
+          _               -> send_direct(conn)
+        end
+        case res do
+          %Conn{} -> res
+          {:error, _reason, _conn} -> res
+          other ->
+            raise "invalid return from #{unquote(__CALLER__.module)}" <>
+                  " expected Maxwell.Conn.t or {:error, reason}, but got: #{inspect other}"
         end
       end
 
@@ -72,11 +85,6 @@ defmodule Maxwell.Adapter do
 
       defoverridable [send_direct: 1, send_multipart: 1, send_file: 1, send_stream: 1] end
   end
-
-  @type return_t :: {:ok, Maxwell.Conn.t} | {:error, any, Maxwell.Conn.t}
-  @callback send_direct(Maxwell.Conn.t) :: return_t
-  @callback send_multipart(Maxwell.Conn.t) :: return_t
-  @callback send_file(Maxwell.Conn.t) :: return_t
 
 end
 

--- a/lib/maxwell/adapter/hackney.ex
+++ b/lib/maxwell/adapter/hackney.ex
@@ -38,11 +38,11 @@ if Code.ensure_loaded?(:hackney) do
         down_key = key |> to_string |> String.downcase
         {down_key, {key, to_string(value)}}
       end
-      {:ok, %{conn | status: status,
-              resp_headers:  headers,
-              req_body:      nil,
-              state:         :sent,
-              resp_body:     body}}
+      %{conn | status:        status,
+               resp_headers:  headers,
+               req_body:      nil,
+               state:         :sent,
+               resp_body:     body}
     end
     defp format_response({:ok, status, headers, body}, conn) do
       case :hackney.body(body) do

--- a/lib/maxwell/adapter/httpc.ex
+++ b/lib/maxwell/adapter/httpc.ex
@@ -84,12 +84,11 @@ defmodule Maxwell.Adapter.Httpc do
       down_key = key |> String.downcase
       {down_key, {key, to_string(value)}}
     end
-    {:ok, %{conn |status:   status,
-            resp_headers:  headers,
-            resp_body:     body,
-            state:         :sent,
-            req_body:      nil}
-    }
+    %{conn | status:        status,
+             resp_headers:  headers,
+             resp_body:     body,
+             state:         :sent,
+             req_body:      nil}
   end
   ## todo {:ok, request_id}
   defp format_response({:error, reason}, conn) do

--- a/lib/maxwell/adapter/ibrowse.ex
+++ b/lib/maxwell/adapter/ibrowse.ex
@@ -62,12 +62,11 @@ if Code.ensure_loaded?(:ibrowse) do
         down_key = key |> to_string |> String.downcase
         {down_key, {key, to_string(value)}}
       end
-      {:ok, %{conn |status:   status,
-              resp_headers:  headers,
-              resp_body:     body,
-              state:         :sent,
-              req_body:      nil}
-      }
+      %{conn | status:        status,
+               resp_headers:  headers,
+               resp_body:     body,
+               state:         :sent,
+               req_body:      nil}
     end
     defp format_response({:error, reason}, conn) do
       {:error, reason, %{conn | state: :error}}

--- a/lib/maxwell/middleware/baseurl.ex
+++ b/lib/maxwell/middleware/baseurl.ex
@@ -1,42 +1,42 @@
 defmodule Maxwell.Middleware.BaseUrl do
   @moduledoc  """
-  ### Examples
+  Sets the base url for all requests in this module.
 
-        #Client.ex
+  ## Examples
+
+        # Client.ex
         use Maxwell.Builder ~(get)a
-        @middleware Maxwell.Middleware.BaseUrl "http{s}://example.com"
+        middleware Maxwell.Middleware.BaseUrl, "http{s}://example.com"
 
         def get_home_page do
-        # request http{s}://example.com"
+          # request http{s}://example.com"
           Client.get!
         end
 
         def request(path) do
-        # http{s}://example.com/\#\{path\}"
+          # http{s}://example.com/\#\{path\}"
           put_path(path) |> Client.get!
         end
 
         def request_other() do
-        # http{s}://other.com/other_path"
-          "http{s}://other.com/other_path" |> new |> Client.get!
+          # http{s}://other.com/other_path"
+          "http{s}://other.com/other_path" |> new() |> Client.get!
           end
 
-  Add query to url.
-
+        # Add query to url.
         def request(url, query)when is_map(query) do
-          url |> new |> put_query_string(query) |> Client.get!
+          url |> new() |> put_query_string(query) |> Client.get!
         end
 
   """
   use Maxwell.Middleware
 
-  def request(env, base_url) do
-    if Regex.match?(~r/^https?:\/\//, env.url) do
-      env
+  def request(%Maxwell.Conn{} = conn, base_url) do
+    if Regex.match?(~r/^https?:\/\//, conn.url) do
+      conn
     else
-      %{env | url: base_url}
+      %{conn | url: base_url}
     end
   end
-
 end
 

--- a/lib/maxwell/middleware/header.ex
+++ b/lib/maxwell/middleware/header.ex
@@ -2,19 +2,18 @@ defmodule Maxwell.Middleware.Headers do
   @moduledoc  """
   Add fixed headers to request's headers
 
-  ### Examples
+  ## Examples
 
         # Client.ex
         use Maxwell.Builder ~(get)a
-        @middleware Maxwell.Middleware.Headers %{'User-Agent' => "zhongwencool"}
+        middleware Maxwell.Middleware.Headers, %{'User-Agent' => "zhongwencool"}
 
         def request do
-        # headers is merge to %{'User-Agent' => "zhongwencool", 'username' => "zhongwencool"}
+          # headers is merge to %{'User-Agent' => "zhongwencool", 'username' => "zhongwencool"}
           %{'username' => "zhongwencool"} |> put_req_header |> get!
         end
 
   """
-
   use Maxwell.Middleware
   alias Maxwell.Conn
 
@@ -23,14 +22,14 @@ defmodule Maxwell.Middleware.Headers do
     %Conn{} |> Conn.put_req_header(headers) |> Map.get(:req_headers)
   end
 
-  def request(conn, req_headers) do
-    %{conn| req_headers: Map.merge(req_headers, conn.req_headers)}
+  def request(%Conn{} = conn, req_headers) do
+    %{conn | req_headers: Map.merge(req_headers, conn.req_headers)}
   end
 
   defp check_headers(headers) do
-    case Enum.all?(headers, fn({key, _value}) -> is_binary(key) end) do
-      true -> :ok
-      false -> raise(ArgumentError, "Headers_map key only accpect string but got: #{inspect headers}");
+    case Enum.all?(headers, fn {key, _value} -> is_binary(key) end) do
+      true  -> :ok
+      false -> raise(ArgumentError, "Header keys must be strings, but got: #{inspect headers}");
     end
   end
 end

--- a/lib/maxwell/middleware/logger.ex
+++ b/lib/maxwell/middleware/logger.ex
@@ -29,7 +29,7 @@ defmodule Maxwell.Middleware.Logger do
       {:error, reason, _conn} ->
         error_reason = to_string(:io_lib.format("~p", [reason]))
         Logger.log(level, "#{method} #{request_env.url}>> #{IO.ANSI.red}ERROR: " <> error_reason)
-      {:ok, response_conn} ->
+      %Maxwell.Conn{} = response_conn ->
         finish_time = :os.timestamp()
         duration = :timer.now_diff(finish_time, start_time)
         duration_ms = :io_lib.format("~.3f", [duration / 10_000])

--- a/lib/maxwell/middleware/opts.ex
+++ b/lib/maxwell/middleware/opts.ex
@@ -2,24 +2,23 @@ defmodule Maxwell.Middleware.Opts do
   @moduledoc  """
   Merge adapter's options (keyword list) to adapter's options
 
-  ### Examples
+  ## Examples
 
          # Client.ex
          use Maxwell.Builder ~(get)a
-         @middleware Maxwell.Middleware.Opts [connect_timeout: 5000]
+         middleware Maxwell.Middleware.Opts, [connect_timeout: 5000]
 
          def request do
-         # opts is [connect_timeout: 5000, cookie: "xxxxcookieyyyy"]
+           # opts is [connect_timeout: 5000, cookie: "xxxxcookieyyyy"]
            put_option(cookie: "xxxxcookieyyyy")|> get!
          end
 
   """
   use Maxwell.Middleware
 
-  def request(env, opts) do
-    new_opts = Keyword.merge(opts, env.opts)
-    %{env | opts: new_opts}
+  def request(%Maxwell.Conn{} = conn, opts) do
+    new_opts = Keyword.merge(opts, conn.opts)
+    %{conn | opts: new_opts}
   end
-
 end
 

--- a/lib/maxwell/middleware/rels.ex
+++ b/lib/maxwell/middleware/rels.ex
@@ -2,17 +2,17 @@ defmodule Maxwell.Middleware.Rels do
   @moduledoc  """
   Decode reponse's body's rels.
 
-  ### Examples
+  ## Examples
 
          # Client.ex
          use Maxwell.Builder ~(get)a
-         @middleware Maxwell.Middleware.Rels
+         middleware Maxwell.Middleware.Rels
 
   """
   use Maxwell.Middleware
 
-  def response(env, _opts) do
-    link = env.headers['Link'] || env.headers["Link"]
+  def response(%Maxwell.Conn{} = conn, _opts) do
+    link = conn.resp_headers['Link'] || conn.resp_headers["Link"]
     if link do
       rels =
       link
@@ -26,12 +26,10 @@ defmodule Maxwell.Middleware.Rels do
            end
          end)
 
-      env
-      |> Map.put(:rels, rels)
+      Map.put(conn, :rels, rels)
     else
-      env
+      conn
     end
   end
-
 end
 

--- a/test/maxwell/adapter/adapter_test.exs
+++ b/test/maxwell/adapter/adapter_test.exs
@@ -7,13 +7,13 @@ defmodule MaxwellAdapterTest do
   defmodule TestAdapter do
     use Maxwell.Adapter
     def send_direct(conn = %Conn{status: nil}) do
-      {:ok, %{conn|status: 200,
-              resp_headers: %{"content-type" => {"Content-Type", "text/plain"}},
-              resp_body: "testbody",
-              state: :sent}}
+      %{conn|status: 200,
+             resp_headers: %{"content-type" => {"Content-Type", "text/plain"}},
+             resp_body: "testbody",
+             state: :sent}
     end
     def send_direct(conn) do
-      {:ok, %{conn| status: 400}}
+      %{conn| status: 400}
     end
   end
 

--- a/test/maxwell/adapter/adapter_test_helper.exs
+++ b/test/maxwell/adapter/adapter_test_helper.exs
@@ -96,9 +96,16 @@ defmodule Maxwell.Adapter.TestHelper do
         end
       end
 
-      setup do
-        :random.seed(:erlang.phash2([node()]), :erlang.monotonic_time, :erlang.unique_integer)
-        :ok
+      if Code.ensure_loaded?(:rand) do
+        setup do
+          :rand.seed(:exs1024, {:erlang.phash2([node()]), :erlang.monotonic_time, :erlang.unique_integer})
+          :ok
+        end
+      else
+        setup do
+          :random.seed(:erlang.phash2([node()]), :erlang.monotonic_time, :erlang.unique_integer)
+          :ok
+        end
       end
 
       test "sync request" do

--- a/test/maxwell/adapter/hackney_test.exs
+++ b/test/maxwell/adapter/hackney_test.exs
@@ -87,9 +87,16 @@ defmodule Maxwell.HackneyMockTest do
 
   end
 
-  setup do
-    :random.seed(:erlang.phash2([node()]), :erlang.monotonic_time, :erlang.unique_integer)
-    :ok
+  if Code.ensure_loaded?(:rand) do
+    setup do
+      :rand.seed(:exs1024, {:erlang.phash2([node()]), :erlang.monotonic_time, :erlang.unique_integer})
+      :ok
+    end
+  else
+    setup do
+      :random.seed(:erlang.phash2([node()]), :erlang.monotonic_time, :erlang.unique_integer)
+      :ok
+    end
   end
 
   test_with_mock "sync request", :hackney,
@@ -98,7 +105,7 @@ defmodule Maxwell.HackneyMockTest do
        [{"Server", "nginx"}, {"Date", "Sun, 18 Dec 2016 03:33:54 GMT"},
         {"Content-Type", "application/json"}, {"Content-Length", "33"},
         {"Connection", "keep-alive"}, {"Access-Control-Allow-Origin", "*"},
-        {"Access-Control-Allow-Credentials", "true"}], make_ref}
+        {"Access-Control-Allow-Credentials", "true"}], make_ref()}
     end,
      body: fn(_) -> {:ok, "{\n  \"origin\": \"183.240.20.213\"\n}\n"} end
     ] do
@@ -111,7 +118,7 @@ defmodule Maxwell.HackneyMockTest do
        [{"Server", "nginx"}, {"Date", "Sun, 18 Dec 2016 03:40:41 GMT"},
         {"Content-Type", "application/json"}, {"Content-Length", "419"},
         {"Connection", "keep-alive"}, {"Access-Control-Allow-Origin", "*"},
-        {"Access-Control-Allow-Credentials", "true"}], make_ref}
+        {"Access-Control-Allow-Credentials", "true"}], make_ref()}
     end,
      body: fn(_) -> {:ok,
                      "{\n  \"args\": {}, \n  \"data\": \"{\\\"josnkey2\\\":\\\"jsonvalue2\\\",\\\"josnkey1\\\":\\\"jsonvalue1\\\"}\", \n  \"files\": {}, \n  \"form\": {}, \n  \"headers\": {\n    \"Content-Length\": \"49\", \n    \"Content-Type\": \"application/json\", \n    \"Host\": \"httpbin.org\", \n    \"User-Agent\": \"hackney/1.6.3\"\n  }, \n  \"json\": {\n    \"josnkey1\": \"jsonvalue1\", \n    \"josnkey2\": \"jsonvalue2\"\n  }, \n  \"origin\": \"183.240.20.213\", \n  \"url\": \"http://httpbin.org/post\"\n}\n"}
@@ -128,7 +135,7 @@ defmodule Maxwell.HackneyMockTest do
        [{"Server", "nginx"}, {"Date", "Sun, 18 Dec 2016 03:42:07 GMT"},
         {"Content-Type", "application/json"}, {"Content-Length", "428"},
         {"Connection", "keep-alive"}, {"Access-Control-Allow-Origin", "*"},
-        {"Access-Control-Allow-Credentials", "true"}], make_ref} end,
+        {"Access-Control-Allow-Credentials", "true"}], make_ref()} end,
      body: fn(_) -> {:ok,
                      "{\n  \"args\": {}, \n  \"data\": \"\", \n  \"files\": {\n    \"file\": \"#!/usr/bin/env bash\\necho \\\"test multipart file\\\"\\n\"\n  }, \n  \"form\": {}, \n  \"headers\": {\n    \"Content-Length\": \"279\", \n    \"Content-Type\": \"multipart/form-data; boundary=---------------------------tvvbujkbhrbruqcy\", \n    \"Host\": \"httpbin.org\", \n    \"User-Agent\": \"hackney/1.6.3\"\n  }, \n  \"json\": null, \n  \"origin\": \"183.240.20.213\", \n  \"url\": \"http://httpbin.org/post\"\n}\n"}
      end ] do
@@ -142,7 +149,7 @@ defmodule Maxwell.HackneyMockTest do
        [{"Server", "nginx"}, {"Date", "Sun, 18 Dec 2016 03:45:10 GMT"},
         {"Content-Type", "application/json"}, {"Content-Length", "428"},
         {"Connection", "keep-alive"}, {"Access-Control-Allow-Origin", "*"},
-        {"Access-Control-Allow-Credentials", "true"}], make_ref}
+        {"Access-Control-Allow-Credentials", "true"}], make_ref()}
     end, body: fn(_) ->
       {:ok,
        "{\n  \"args\": {}, \n  \"data\": \"\", \n  \"files\": {\n    \"file\": \"#!/usr/bin/env bash\\necho \\\"test multipart file\\\"\\n\"\n  }, \n  \"form\": {}, \n  \"headers\": {\n    \"Content-Length\": \"273\", \n    \"Content-Type\": \"multipart/form-data; boundary=---------------------------dlhrimiytrrvmxqk\", \n    \"Host\": \"httpbin.org\", \n    \"User-Agent\": \"hackney/1.6.3\"\n  }, \n  \"json\": null, \n  \"origin\": \"183.240.20.213\", \n  \"url\": \"http://httpbin.org/post\"\n}\n"}
@@ -157,7 +164,7 @@ defmodule Maxwell.HackneyMockTest do
        [{"Server", "nginx"}, {"Date", "Sun, 18 Dec 2016 03:46:14 GMT"},
         {"Content-Type", "application/json"}, {"Content-Length", "352"},
         {"Connection", "keep-alive"}, {"Access-Control-Allow-Origin", "*"},
-        {"Access-Control-Allow-Credentials", "true"}], make_ref}
+        {"Access-Control-Allow-Credentials", "true"}], make_ref()}
     end,
      body: fn(_) ->
        {:ok,
@@ -169,7 +176,7 @@ defmodule Maxwell.HackneyMockTest do
 
   test_with_mock "send stream", :hackney,
     [request: fn(_,_,_,_,_) ->
-      {:ok, make_ref}
+      {:ok, make_ref()}
     end,
      send_body: fn(_, _) -> :ok end,
      start_response: fn(_) ->
@@ -177,7 +184,7 @@ defmodule Maxwell.HackneyMockTest do
         [{"Server", "nginx"}, {"Date", "Sun, 18 Dec 2016 03:47:26 GMT"},
          {"Content-Type", "application/json"}, {"Content-Length", "267"},
          {"Connection", "keep-alive"}, {"Access-Control-Allow-Origin", "*"},
-         {"Access-Control-Allow-Credentials", "true"}], make_ref}
+         {"Access-Control-Allow-Credentials", "true"}], make_ref()}
      end,
      body: fn(_) ->
        {:ok,
@@ -190,7 +197,7 @@ defmodule Maxwell.HackneyMockTest do
   test_with_mock "send stream error", :hackney,
     [request: fn(_,_,_,_,_) -> {:error, :closed} end,
      send_body: fn(_, _) -> {:error, :closed} end,
-     start_response: fn(_) -> {:ok, 200, [], make_ref} end,
+     start_response: fn(_) -> {:ok, 200, [], make_ref()} end,
      body: fn(_) -> {:ok, "error connection closed"}
      end ] do
     assert_raise(Maxwell.Error,
@@ -204,7 +211,7 @@ defmodule Maxwell.HackneyMockTest do
        [{"Server", "nginx"}, {"Date", "Sun, 18 Dec 2016 03:52:41 GMT"},
         {"Content-Type", "application/json"}, {"Content-Length", "27"},
         {"Connection", "keep-alive"}, {"Access-Control-Allow-Origin", "*"},
-        {"Access-Control-Allow-Credentials", "true"}], make_ref}
+        {"Access-Control-Allow-Credentials", "true"}], make_ref()}
     end,
      body: fn(_) ->
        {:ok, "{\n  \"user-agent\": \"test\"\n}\n"}
@@ -218,7 +225,7 @@ defmodule Maxwell.HackneyMockTest do
        [{"Server", "nginx"}, {"Date", "Sun, 18 Dec 2016 03:54:56 GMT"},
         {"Content-Type", "application/json"}, {"Content-Length", "339"},
         {"Connection", "keep-alive"}, {"Access-Control-Allow-Origin", "*"},
-        {"Access-Control-Allow-Credentials", "true"}], make_ref}
+        {"Access-Control-Allow-Credentials", "true"}], make_ref()}
     end, body: fn(_) ->
       {:ok,
        "{\n  \"args\": {}, \n  \"data\": \"{\\\"key\\\":\\\"value\\\"}\", \n  \"files\": {}, \n  \"form\": {}, \n  \"headers\": {\n    \"Content-Length\": \"15\", \n    \"Content-Type\": \"application/json\", \n    \"Host\": \"httpbin.org\", \n    \"User-Agent\": \"hackney/1.6.3\"\n  }, \n  \"json\": {\n    \"key\": \"value\"\n  }, \n  \"origin\": \"183.240.20.213\", \n  \"url\": \"http://httpbin.org/put\"\n}\n"}
@@ -232,7 +239,7 @@ defmodule Maxwell.HackneyMockTest do
        [{"Server", "nginx"}, {"Date", "Sun, 18 Dec 2016 03:53:52 GMT"},
         {"Content-Type", "application/json"}, {"Content-Length", "233"},
         {"Connection", "keep-alive"}, {"Access-Control-Allow-Origin", "*"},
-        {"Access-Control-Allow-Credentials", "true"}], make_ref}
+        {"Access-Control-Allow-Credentials", "true"}], make_ref()}
     end, body: fn(_) ->
       {:ok,
        "{\n  \"args\": {}, \n  \"data\": \"\", \n  \"files\": {}, \n  \"form\": {}, \n  \"headers\": {\n    \"Host\": \"httpbin.org\", \n    \"User-Agent\": \"hackney/1.6.3\"\n  }, \n  \"json\": null, \n  \"origin\": \"183.240.20.213\", \n  \"url\": \"http://httpbin.org/delete\"\n}\n"}
@@ -246,7 +253,7 @@ defmodule Maxwell.HackneyMockTest do
        [{"Server", "nginx"}, {"Date", "Sun, 18 Dec 2016 03:53:52 GMT"},
         {"Content-Type", "application/json"}, {"Content-Length", "233"},
         {"Connection", "keep-alive"}, {"Access-Control-Allow-Origin", "*"},
-        {"Access-Control-Allow-Credentials", "true"}], make_ref}
+        {"Access-Control-Allow-Credentials", "true"}], make_ref()}
     end, body: fn(_) ->
       {:error, {:closed, ""}}
     end ] do

--- a/test/maxwell/adapter/httpc_test.exs
+++ b/test/maxwell/adapter/httpc_test.exs
@@ -96,9 +96,16 @@ defmodule Maxwell.HttpcMockTest do
 
   end
 
-  setup do
-    :random.seed(:erlang.phash2([node()]), :erlang.monotonic_time, :erlang.unique_integer)
-    :ok
+  if Code.ensure_loaded?(:rand) do
+    setup do
+      :rand.seed(:exs1024, {:erlang.phash2([node()]), :erlang.monotonic_time, :erlang.unique_integer})
+      :ok
+    end
+  else
+    setup do
+      :random.seed(:erlang.phash2([node()]), :erlang.monotonic_time, :erlang.unique_integer)
+      :ok
+    end
   end
   test_with_mock "sync request", :httpc,
     [request: fn(_,_,_,_) ->
@@ -240,7 +247,7 @@ defmodule Maxwell.HttpcMockTest do
     [request: fn(_,_,_,_) ->
       {:error, :timeout}
     end] do
-    {:error, :timeout, conn} = Client.timeout_test |> IO.inspect
+    {:error, :timeout, conn} = Client.timeout_test
     assert conn.state == :error
   end
 

--- a/test/maxwell/adapter/ibrowse_test.exs
+++ b/test/maxwell/adapter/ibrowse_test.exs
@@ -97,9 +97,16 @@ defmodule Maxwell.IbrowseMockTest do
 
   end
 
-  setup do
-    :random.seed(:erlang.phash2([node()]), :erlang.monotonic_time, :erlang.unique_integer)
-    :ok
+  if Code.ensure_loaded?(:rand) do
+    setup do
+      :rand.seed(:exs1024, {:erlang.phash2([node()]), :erlang.monotonic_time, :erlang.unique_integer})
+      :ok
+    end
+  else
+    setup do
+      :random.seed(:erlang.phash2([node()]), :erlang.monotonic_time, :erlang.unique_integer)
+      :ok
+    end
   end
 
   test_with_mock "sync request", :ibrowse,

--- a/test/maxwell/middleware/base_url_test.exs
+++ b/test/maxwell/middleware/base_url_test.exs
@@ -2,14 +2,15 @@ defmodule BaseUrlTest do
   use ExUnit.Case
   import Maxwell.Middleware.TestHelper
   alias Maxwell.Conn
+
   test "Base Middleware.BaseUrl" do
     conn = request(Maxwell.Middleware.BaseUrl, %Conn{url: "/path"}, "http://example.com")
     assert conn.url == "http://example.com"
   end
+
   test "Replace http Middleware.BaseUrl" do
-    conn = request(Maxwell.Middleware.BaseUrl, %{url: "http://see_me.com/path"}, "http://can_not_seen.com/")
+    conn = request(Maxwell.Middleware.BaseUrl, %Conn{url: "http://see_me.com/path"}, "http://can_not_seen.com/")
     assert conn.url == "http://see_me.com/path"
   end
-
 end
 

--- a/test/maxwell/middleware/decode_rels_test.exs
+++ b/test/maxwell/middleware/decode_rels_test.exs
@@ -1,16 +1,17 @@
 defmodule RelsTest do
   use ExUnit.Case
   import Maxwell.Middleware.TestHelper
+  alias Maxwell.Conn
 
   test "Header Without Link Middleware Rels" do
-    conn = response(Maxwell.Middleware.Rels, %{headers: %{}}, [])
-    assert conn == %{headers: %{}}
+    conn = response(Maxwell.Middleware.Rels, %Conn{resp_headers: %{}}, [])
+    assert conn == %Conn{resp_headers: %{}}
   end
 
   test "Header With Link Middleware Rels and match" do
     conn =
       response(Maxwell.Middleware.Rels,
-        %{headers: %{'Link' => "<http://localhost/users?page=1>; rel=test1, <http://localhost/users?page=2>; rel=test2, <http://localhost/users?page=3>; rel=test3"}},
+        %Conn{resp_headers: %{'Link' => "<http://localhost/users?page=1>; rel=test1, <http://localhost/users?page=2>; rel=test2, <http://localhost/users?page=3>; rel=test3"}},
         [])
     assert Map.get(conn.rels, "test1") == "<http://localhost/users?page=1>"
     assert Map.get(conn.rels, "test2") == "<http://localhost/users?page=2>"
@@ -20,7 +21,7 @@ defmodule RelsTest do
   test "Header With Link Middleware Rels and don't match" do
     conn =
       response(Maxwell.Middleware.Rels,
-        %{headers: %{'Link' => "lkdfjldkjfdwrongformat"}},
+        %Conn{resp_headers: %{'Link' => "lkdfjldkjfdwrongformat"}},
         [])
 
     assert conn.rels == %{}

--- a/test/maxwell/middleware/header_test.exs
+++ b/test/maxwell/middleware/header_test.exs
@@ -19,7 +19,7 @@ defmodule HeaderTest do
   end
 
   test "header key is not string" do
-    assert_raise ArgumentError, "Headers_map key only accpect string but got: %{key: \"value\"}", fn ->
+    assert_raise ArgumentError, "Header keys must be strings, but got: %{key: \"value\"}", fn ->
       defmodule TAtom111 do
         use Maxwell.Builder, [:get, :post]
         middleware Maxwell.Middleware.Headers, %{:key => "value"}

--- a/test/maxwell/middleware/json_test.exs
+++ b/test/maxwell/middleware/json_test.exs
@@ -6,41 +6,34 @@ defmodule JsonTest do
       conn = %{conn|state: :sent}
       case conn.path do
         "/decode" ->
-          {:ok,
            %{conn| status: 200, resp_headers: %{"content-type" => {"Content-Type", "application/json"}},
-             resp_body: "{\"value\": 123}"}}
+             resp_body: "{\"value\": 123}"}
         "/decode_error" ->
-          {:ok,
            %{conn| status: 200, resp_headers: %{"content-type" => {"Content-Type", "application/json"}},
-             resp_body: "\"123"}}
+             resp_body: "\"123"}
         "/encode" ->
-          {:ok,
            %{conn| status: 200, resp_headers: %{"content-type" => {"Content-Type", "application/json"}},
-             resp_body: conn.req_body |> String.replace("foo", "baz")}}
+             resp_body: conn.req_body |> String.replace("foo", "baz")}
         "/empty" ->
-          {:ok,
            %{conn| status: 200, resp_headers: %{"content-type" => {"Content-Type", "application/json"}},
-             resp_body: nil}}
+             resp_body: nil}
         "/tuple" ->
-          {:ok,
            %{conn| status: 200, resp_headers: %{"content-type" => {"Content-Type", "application/json"}},
-             resp_body: {:key, :value}}}
+             resp_body: {:key, :value}}
         "/invalid-content-type" ->
-          {:ok,
            %{conn| status: 200, resp_headers: %{"content-type" => {"Content-Type", "text/plain"}},
-             resp_body: "hello"}}
+             resp_body: "hello"}
         "/use-defined-content-type" ->
-          {:ok,
            %{conn| status: 200, resp_headers: %{"content-type" => {"Content-Type", "text/html"}},
-             resp_body: "{\"value\": 124}"}};
+             resp_body: "{\"value\": 124}"}
         "/not_found_404" ->
-          {:ok, %{conn| status: 404, resp_body: "404 Not Found"}}
+          %{conn| status: 404, resp_body: "404 Not Found"}
         "/redirection_301" ->
-          {:ok, %{conn| status: 301, resp_body: "301 Moved Permanently"}}
+          %{conn| status: 301, resp_body: "301 Moved Permanently"}
         "/error" ->
-          {:error, "hahahaha"}
+          {:error, "hahahaha", conn}
         _ ->
-          {:ok, %{conn| status: 200}}
+          %{conn| status: 200}
       end
     end
   end
@@ -130,16 +123,16 @@ defmodule JsonTest do
       |> Conn.put_path
       |> Conn.put_req_body(%{"foo" => "bar"})
     |> Client.post
-    assert result == {:error, "hahahaha"}
+    assert {:error, "hahahaha", %Conn{}} = result
   end
 end
 
 defmodule ModuleAdapter2 do
   def call(conn) do
-    {:ok, %{conn|status: 200,
+    %{conn|status: 200,
             state: :sent,
             resp_headers: %{"content-type" => {"Content-Type","text/javascript"}},
-            resp_body: "{\"value\": 124}"}}
+            resp_body: "{\"value\": 124}"}
   end
 end
 

--- a/test/maxwell/middleware/logger_test.exs
+++ b/test/maxwell/middleware/logger_test.exs
@@ -10,7 +10,7 @@ defmodule LoggerTest do
   end
 
   test "Middleware Logger Response" do
-    {:ok, conn} = response(Maxwell.Middleware.Logger, {:ok, %Conn{url: "/path"}}, [])
+    conn = response(Maxwell.Middleware.Logger, %Conn{url: "/path"}, [])
     assert conn == %Conn{url: "/path"}
   end
 
@@ -18,10 +18,10 @@ defmodule LoggerTest do
     conn = %Conn{method: :get, url: "http://example.com", status: 200}
     outputstr = capture_log fn ->
       Maxwell.Middleware.Logger.call(conn,fn(x) ->{:error, "bad request", %{x| status: 400}} end, :info) end
-    output301 = capture_log fn -> Maxwell.Middleware.Logger.call(conn, fn(x) -> {:ok, %{x| status: 301}} end, :info) end
-    output404 = capture_log fn -> Maxwell.Middleware.Logger.call(conn, fn(x) -> {:ok, %{x| status: 404}} end, :info) end
-    output500 = capture_log fn -> Maxwell.Middleware.Logger.call(conn, fn(x) -> {:ok, %{x| status: 500}} end, :info) end
-    outputok  = capture_log fn -> Maxwell.Middleware.Logger.call(conn, fn(x) -> {:ok, x} end, :info) end
+    output301 = capture_log fn -> Maxwell.Middleware.Logger.call(conn, fn(x) -> %{x| status: 301} end, :info) end
+    output404 = capture_log fn -> Maxwell.Middleware.Logger.call(conn, fn(x) -> %{x| status: 404} end, :info) end
+    output500 = capture_log fn -> Maxwell.Middleware.Logger.call(conn, fn(x) -> %{x| status: 500} end, :info) end
+    outputok  = capture_log fn -> Maxwell.Middleware.Logger.call(conn, fn(x) -> x end, :info) end
     assert outputstr =~ ~r"\e\[22m\n\d+:\d+:\d+.\d+ \[info\]  GET http://example.com>> \e\[31mERROR: <<\"bad request\">>\n\e\[0m"
 
     assert output301 =~ ~r"\e\[22m\n\d+:\d+:\d+.\d+ \[info\]  get http://example.com <<<\e\[33m301\(\d+.\d+ms\)\e\[0m\n%Maxwell.Conn\{method: :get, opts: \[\], path: \"\", query_string: \%\{\}, req_body: nil, req_headers: \%\{\}, resp_body: \"\", resp_headers: \%\{\}, state: :unsent, status: 301, url: \"http://example.com\"\}\n\e\[0m"

--- a/test/maxwell/middleware/middleware_test.exs
+++ b/test/maxwell/middleware/middleware_test.exs
@@ -6,11 +6,11 @@ defmodule MiddlewareTest do
       conn = %{conn| state: :sent}
       body = unless conn.req_body, do: %{}, else: Poison.decode!(conn.req_body)
       if Map.equal?(body, %{"key2" => 101, "key1" => 201}) do
-        {:ok, %{conn| status: 200, resp_headers: %{"content-type" => {"Content-Type", "application/json"}},
-                resp_body: "{\"key2\":101,\"key1\":201}"}}
+        %{conn| status: 200, resp_headers: %{"content-type" => {"Content-Type", "application/json"}},
+                resp_body: "{\"key2\":101,\"key1\":201}"}
       else
-          {:ok, %{conn| status: 200, resp_headers: %{"content-type" => {"Content-Type", "application/json"}},
-                  resp_body: "{\"key2\":2,\"key1\":1}"}}
+        %{conn| status: 200, resp_headers: %{"content-type" => {"Content-Type", "application/json"}},
+                resp_body: "{\"key2\":2,\"key1\":1}"}
       end
     end
   end

--- a/test/maxwell/multipart_test.exs
+++ b/test/maxwell/multipart_test.exs
@@ -1,9 +1,16 @@
 defmodule MultipartTest do
   use ExUnit.Case
 
-  setup do
-    :random.seed(:erlang.phash2([node()]), :erlang.monotonic_time, :erlang.unique_integer)
-    :ok
+  if Code.ensure_loaded?(:rand) do
+    setup do
+      :rand.seed(:exs1024, {:erlang.phash2([node()]), :erlang.monotonic_time, :erlang.unique_integer})
+      :ok
+    end
+  else
+    setup do
+      :random.seed(:erlang.phash2([node()]), :erlang.monotonic_time, :erlang.unique_integer)
+      :ok
+    end
   end
 
   test "Boundary" do


### PR DESCRIPTION
See our previous discussion on #30

This PR touches many modules, but all changes are relatively small. If you have any concerns about any of them, let me know and I can try to explain in more detail.

- Adapters now return Maxwell.Conn.t instead of {:ok, Maxwell.Conn.t}
- Middleware are now unified around returning Maxwell.Conn.t instead of
  {:ok, Maxwell.Conn.t}
- Fix broken Rels middleware
- Update and add missing typespecs
- Update tests (and fix test warnings on newer Erlang/Elixir versions)
- A few documentation tweaks, spelling, etc.

The gist is the following:

- Existing third-party middleware modules should not need to make any changes
- Third-party adapter modules *will* need to ensure they return `Maxwell.Conn.t` instead of `{:ok, Maxwell.Conn.t}`, this is a breaking change, but essential to fix the internal consistency issues.
- Existing built-in middlewares that were previously broken are now working as expected.