### PR TITLE
A collection of general API improvements

### DIFF
--- a/lib/maxwell/adapter/hackney.ex
+++ b/lib/maxwell/adapter/hackney.ex
@@ -34,10 +34,9 @@ if Code.ensure_loaded?(:hackney) do
     end
 
     defp format_response({:ok, status, headers, body}, conn) when is_binary(body) do
-      headers = for {key, value} <- headers, into: %{} do
-        down_key = key |> to_string |> String.downcase
-        {down_key, {key, to_string(value)}}
-      end
+      headers = Enum.reduce(headers, %{}, fn {k, v}, acc ->
+        Map.put(acc, String.downcase(to_string(k)), to_string(v))
+      end)
       %{conn | status:        status,
                resp_headers:  headers,
                req_body:      nil,
@@ -57,8 +56,6 @@ if Code.ensure_loaded?(:hackney) do
     defp format_response({:error, reason}, conn) do
       {:error, reason, %{conn | state: :error}}
     end
-
   end
-
 end
 

--- a/lib/maxwell/adapter/httpc.ex
+++ b/lib/maxwell/adapter/httpc.ex
@@ -66,10 +66,10 @@ defmodule Maxwell.Adapter.Httpc do
 
   defp header_serialize(headers) do
     {content_type, headers} = Map.pop(headers, "content-type")
-    headers = Enum.map(headers, fn({_, {key, value}}) -> {to_char_list(key), to_char_list(value)} end)
+    headers = Enum.map(headers, fn {key, value} -> {to_char_list(key), to_char_list(value)} end)
     case content_type do
-      nil -> {nil, headers}
-      {_, type} -> {to_char_list(type), headers}
+      nil  -> {nil, headers}
+      type -> {to_char_list(type), headers}
     end
   end
 
@@ -80,9 +80,7 @@ defmodule Maxwell.Adapter.Httpc do
   defp format_response({:ok, {status_line, headers, body}}, conn) do
     {_http_version, status, _reason_phrase} = status_line
     headers = for {key, value} <- headers, into: %{} do
-      key = key |> to_string
-      down_key = key |> String.downcase
-      {down_key, {key, to_string(value)}}
+      {String.downcase(to_string(key)), to_string(value)}
     end
     %{conn | status:        status,
              resp_headers:  headers,
@@ -107,6 +105,5 @@ defmodule Maxwell.Adapter.Httpc do
   defp format_response({:error, reason}, conn) do
     {:error, reason, %{conn | state: :error}}
   end
-
 end
 

--- a/lib/maxwell/adapter/ibrowse.ex
+++ b/lib/maxwell/adapter/ibrowse.ex
@@ -58,10 +58,9 @@ if Code.ensure_loaded?(:ibrowse) do
 
     defp format_response({:ok, status, headers, body}, conn) do
       {status, _} = status |> to_string |> Integer.parse
-      headers = for {key, value} <- headers, into: %{} do
-        down_key = key |> to_string |> String.downcase
-        {down_key, {key, to_string(value)}}
-      end
+      headers = Enum.reduce(headers, %{}, fn {k, v}, acc ->
+        Map.put(acc, String.downcase(to_string(k)), to_string(v))
+      end)
       %{conn | status:        status,
                resp_headers:  headers,
                resp_body:     body,
@@ -77,8 +76,6 @@ if Code.ensure_loaded?(:ibrowse) do
     defp format_response({:error, reason}, conn) do
       {:error, reason, %{conn | state: :error}}
     end
-
   end
-
 end
 

--- a/lib/maxwell/adapter/util.ex
+++ b/lib/maxwell/adapter/util.ex
@@ -31,19 +31,17 @@ defmodule Maxwell.Adapter.Util do
   end
 
   @doc """
-  Make headers to key word list.
+  Converts the headers map to a list of tuples.
 
-     * `headers`   - `Map.t`, for example: `%{"content-type" => {"Content-Type", "application/json"}}`
+     * `headers`   - `Map.t`, for example: `%{"content-type" => "application/json"}`
 
   ### Examples
 
-       #[{"Content-Type", "application/json"}]
-       iex> headers_serialize(%{"content-type" => {"Content-Type", "application/json"}})
-
+       iex> headers_serialize(%{"content-type" => "application/json"})
+       [{"content-type", "application/json"}]
   """
-
   def header_serialize(headers) do
-    headers |> Map.values
+    Enum.into(headers, [])
   end
 
   @doc """
@@ -83,9 +81,8 @@ defmodule Maxwell.Adapter.Util do
   """
   def chunked?(conn) do
     case Conn.get_req_header(conn, "transfer-encoding") do
-      {_, "chunked"} -> true
-      {_, type} -> "chunked" == String.downcase(type)
-      nil -> false
+      nil       -> false
+      type      -> "chunked" == String.downcase(type)
     end
   end
 
@@ -122,15 +119,15 @@ defmodule Maxwell.Adapter.Util do
     case next_stream_fun.({:cont, nil}) do
       {:suspended, item, next_stream_fun} -> {:ok, item, next_stream_fun}
       {:halted, _} -> :eof
-      {:done, _} -> :eof
+      {:done, _}   -> :eof
     end
   end
   def stream_iterate(stream) do
-		case Enumerable.reduce(stream, {:cont, nil}, fn(item, nil)-> {:suspend, item} end) do
+    case Enumerable.reduce(stream, {:cont, nil}, fn(item, nil)-> {:suspend, item} end) do
       {:suspended, item, next_stream} -> {:ok, item, next_stream}
-			{:done, _} -> :eof
+      {:done, _}   -> :eof
       {:halted, _} -> :eof
-		end
+	end
   end
 
   defp multipart_body({:start, boundary, multiparts}) do

--- a/lib/maxwell/conn.ex
+++ b/lib/maxwell/conn.ex
@@ -1,32 +1,37 @@
 defmodule Maxwell.Conn do
   @moduledoc """
   The Maxwell connection.
+
   This module defines a `Maxwell.Conn` struct and the main functions
   for working with Maxwell connections.
 
   ### Request fields
+
   These fields contain request information:
 
      * `url` - the requested url as a binary, example: `"www.example.com:8080/path/?foo=bar"`.
      * `method` - the request method as a atom, example: `GET`.
-     * `req_headers` - the request headers as a list, example: `[{"content-type", "text/plain"}]`.
+     * `req_headers` - the request headers as a map, example: `%{"content-type" => "text/plain"}`.
      * `req_body` - the request body, by default is an empty string. It is set
         to nil after the request is set.
 
   ### Response fields
+
   These fields contain response information:
 
      * `status` - the response status
-     * `resp_headers` - the response headers as a list of tuples.
+     * `resp_headers` - the response headers as a map.
      * `resp_body` - the response body (todo desc).
 
   ### Connection fields
 
      * `state` - the connection state
+
   The connection state is used to track the connection lifecycle. It starts
   as `:unsent` but is changed to `:sending`, Its final result is `:sent` or `:error`. 
 
   ### Protocols
+
   `Maxwell.Conn` implements both the Collectable and Inspect protocols
     out of the box. The inspect protocol provides a nice representation
     of the connection while the collectable protocol allows developers
@@ -39,17 +44,17 @@ defmodule Maxwell.Conn do
          Enum.into(~w(each chunk as a word), conn)
 
   """
-  @type conn_t :: %__MODULE__{
+  @type t :: %__MODULE__{
     state: :unsent | :sending | :sent | :error,
     method: Atom.t,
     url: String.t,
     path: String.t,
     query_string: Map.t,
     opts: Keyword.t,
-    req_headers: %{binary => {binary, binary}},
+    req_headers: %{binary => binary},
     req_body: iodata | Map.t,
     status: non_neg_integer | nil,
-    resp_headers: %{binary => {binary, binary}},
+    resp_headers: %{binary => binary},
     resp_body: iodata | Map.t
   }
 
@@ -68,53 +73,77 @@ defmodule Maxwell.Conn do
   alias Maxwell.Conn
 
   defmodule AlreadySentError do
-    defexception message: "the request was already sent"
-
     @moduledoc """
     Error raised when trying to modify or send an already sent request
     """
+    defexception message: "the request was already sent"
   end
-  defmodule NotSentError do
-    defexception message: "the request was not sent yet"
 
+  defmodule NotSentError do
     @moduledoc """
     Error raised when no request is sent in a connection
     """
+    defexception message: "the request was not sent yet"
   end
 
   @doc """
-  Create a `%Maxwell.Conn{}`
-
-  * `url` - the base url.
+  Create a new connection.
+  The url provided will be parsed by `URI.parse/1`, and the relevant connection fields will
+  be set accordingly.
 
   ### Examples
 
-      # %Maxwell.Conn{}
-      conn = new()
-      # %Maxwell.Conn{url = "http://example.com"}
-      conn = new("http://example.com")
+      iex> new()
+      %Maxwell.Conn{}
 
+      iex> new("http://example.com/foo")
+      %Maxwell.Conn{url: "http://example.com", path: "/foo"}
+
+      iex> new("http://example.com/foo?bar=qux")
+      %Maxwell.Conn{url: "http://example.com", path: "/foo", query_string: %{"bar" => "qux"}}
   """
-  def new(url \\ ""), do: %Maxwell.Conn{url: url}
+  def new(), do: %Conn{}
+  def new(url) when is_binary(url) do
+    uri    = URI.parse(url)
+    scheme = uri.scheme || "http"
+    path   = uri.path || ""
+    conn = case uri do
+      %URI{host: nil} ->
+        %Conn{path: path}
+      %URI{userinfo: nil, port: nil} = uri ->
+        %Conn{url: "#{scheme}://#{uri.host}", path: path}
+      %URI{userinfo: nil, scheme: "http", port: 80} = uri  ->
+        %Conn{url: "#{scheme}://#{uri.host}", path: path}
+      %URI{userinfo: nil, scheme: "https", port: 443} = uri  ->
+        %Conn{url: "#{scheme}://#{uri.host}", path: path}
+      %URI{userinfo: nil, port: port} = uri  ->
+        %Conn{url: "#{scheme}://#{uri.host}:#{port}", path: path}
+      %URI{userinfo: userinfo, port: port} = uri ->
+        %Conn{url: "#{scheme}://#{userinfo}@#{uri.host}:#{port}", path: path}
+    end
+    case uri.query do
+      nil   -> conn
+      query -> put_query_string(conn, URI.decode_query(query))
+    end
+  end
 
   @doc """
-  Replace `path` in `conn.path`.
-
-    * `path` - path string, for example `"/path/to/home"`
-    * `conn` - `%Conn{}`
+  Set the path of the request.
 
   ### Examples
 
-       @middleware Maxwell.Middleware.BaseUrl "http://example.com"
-       #%Conn{path: "delete", url: "http://example.com"}
-       put_path("delete")
-       #or
-       new() |> put_path("delete")
-
+       iex> put_path(new(), "delete")
+       %Maxwell.Conn{path: "delete"}
   """
-  def put_path(conn \\ %Conn{}, path)
-  def put_path(conn = %Conn{state: :unsent}, path), do: %{conn| path: path}
+  @spec put_path(Conn.t, String.t) :: Conn.t | no_return
+  def put_path(%Conn{state: :unsent} = conn, path), do: %{conn | path: path}
   def put_path(_conn, _path), do: raise AlreadySentError
+
+  @doc false
+  def put_path(path) when is_binary(path) do
+    IO.warn "put_path/1 is deprecated, use new/1 or new/2 followed by put_path/2 instead", System.stacktrace
+    put_path(new(), path)
+  end
 
   @doc """
   Add query string to `conn.query_string`.
@@ -128,188 +157,263 @@ defmodule Maxwell.Conn do
       put_query_string(%Conn{}, %{name: "zhong wen"})
 
   """
-  def put_query_string(conn \\ %Conn{}, query_map)
-  def put_query_string(conn = %Conn{state: :unsent, query_string: query_string}, query_map) do
-    %{conn| query_string: Map.merge(query_string, query_map)}
+  @spec put_query_string(Conn.t, map()) :: Conn.t | no_return
+  def put_query_string(%Conn{state: :unsent, query_string: qs} = conn, query) do
+    %{conn | query_string: Map.merge(qs, query)}
   end
   def put_query_string(_conn, _query_map), do: raise AlreadySentError
 
-  @doc """
-  Add query string to `conn.query_string`.
+  @doc false
+  def put_query_string(query) when is_map(query) do
+    IO.warn "put_query_string/1 is deprecated, use new/1 or new/2 followed by put_query_string/2 instead", System.stacktrace
+    put_query_string(new(), query)
+  end
 
-  * `conn` - `%Conn{}`
-  * `key` - query key, for example `"name"`.
-  * `value` - query value, for example `"lucy"`.
+  @doc """
+  Set a query string value for the request.
 
   ### Examples
 
-        # %Conn{query_string: %{name: "zhong wen"}}
-        put_query_string(%Conn{}, :name, "zhong wen")
-
+        iex> put_query_string(new(), :name, "zhong wen")
+        %Maxwell.Conn{query_string: %{:name => "zhong wen"}}
   """
-  def put_query_string(conn = %Conn{state: :unsent, query_string: query_string}, key, value) do
-    %{conn| query_string: Map.put(query_string, key, value)}
+  def put_query_string(%Conn{state: :unsent, query_string: qs} = conn, key, value) do
+    %{conn | query_string: Map.put(qs, key, value)}
   end
   def put_query_string(_conn, _key, _value), do: raise AlreadySentError
 
   @doc """
-  Merge http headers.
-
-    * `conn` - `%Conn{}`
-    * `req_headers` - reqeust headers, for example `%{"content-type" => "text/javascript"}`
+  Merge a map of headers into the existing headers of the connection.
 
   ### Examples
 
-      # %Conn{headers: %{"Content-Type" => "application/json", "User-Agent" => "zhongwenool"}
-      %Conn{headers: %{"Content-Type" => "text/javascript"}
-      |> put_req_header(%{"Content-Type" => "application/json"})
-      |> put_req_header(%{"User-Agent" => "zhongwencool"})
-
+      iex> %Maxwell.Conn{headers: %{"content-type" => "text/javascript"}
+      |> put_req_headers(%{"Accept" => "application/json"})
+      %Maxwell.Conn{req_headers: %{"accept" => "application/json", "content-type" => "text/javascript"}}
   """
-  def put_req_header(conn \\ %Conn{}, map_headers)
-  def put_req_header(conn = %Conn{state: :unsent, req_headers: headers}, map_headers)when is_map(map_headers) do
-    downcase_func =
-    fn({downcase_header, {_original_header, _header_value} = value}, acc) ->
-      Map.put(acc, downcase_header, value)
-      ({header, _val} = value, acc) ->
-        Map.put(acc, String.downcase(header), value)
-    end
-    new_headers = Enum.reduce(map_headers, headers, downcase_func)
-    %{conn| req_headers: new_headers}
+  @spec put_req_headers(Conn.t, map()) :: Conn.t | no_return
+  def put_req_headers(%Conn{state: :unsent, req_headers: headers} = conn, extra_headers) when is_map(extra_headers) do
+    new_headers =
+    extra_headers
+    |> Enum.reduce(headers, fn {header_name, header_value}, acc ->
+      acc
+      |> Map.delete(header_name)
+      |> Map.put(String.downcase(header_name), header_value)
+    end)
+    %{conn | req_headers: new_headers}
   end
-  def put_req_header(_conn, _map_headers), do: raise AlreadySentError
+  def put_req_headers(_conn, _headers), do: raise AlreadySentError
+
+  # TODO: Remove
+  @doc false
+  def put_req_header(headers) do
+    IO.warn "put_req_header/1 is deprecated, use new/1 or new/2 followed by put_req_headers/2 instead", System.stacktrace
+    put_req_headers(new(), headers)
+  end
+
+  # TODO: Remove
+  @doc false
+  def put_req_header(conn, headers) when is_map(headers) do
+    IO.warn "put_req_header/2 is deprecated, use put_req_headers/1 instead", System.stacktrace
+    put_req_headers(conn, headers)
+  end
 
   @doc """
-  Merge http headers.
-
-  * `conn` - `%Conn{}`
-  * `key` - header key
-  * `value` - header value
+  Set a request header. If it already exists, it is updated.
 
   ### Examples
 
-      # %Conn{headers: %{"content-type" => {"Content-Type", "application/json"}, "user-agent" => {"user-agent", "zhongwenool"}}
-      %Conn{headers: %{"content-type" => {"Content-Type", "text/javascript"}}
+      iex> %Maxwell.Conn{req_headers: %{"content-type" => "text/javascript"}}
       |> put_req_header("Content-Type", "application/json")
       |> put_req_header("User-Agent", "zhongwencool")
-
+      %Maxwell.Conn{req_headers: %{"content-type" => "application/json", "user-agent" => "zhongwenool"}
   """
-  def put_req_header(conn = %Conn{state: :unsent, req_headers: headers}, key, value) do
-    %{conn| req_headers: Map.put(headers,  String.downcase(key), {key, value})}
+  def put_req_header(%Conn{state: :unsent, req_headers: headers} = conn, key, value) do
+    new_headers =
+    headers
+    |> Map.delete(key)
+    |> Map.put(String.downcase(key), value)
+    %{conn | req_headers: new_headers}
   end
   def put_req_header(_conn, _key, _value), do: raise AlreadySentError
 
   @doc """
-
-  * `get_req_header/1` - get all request headers, return `Map.t`.
-  * `get_req_header/2` - get request header by `key`, return value.
-  * `conn` - `%Conn{}`
+  Get all request headers as a map
 
   ### Examples
 
-  # {"Cookie", "xyz"}
-  %Conn{req_headers: %{"cookie" => {"Cookie", "xyz"}} |> get_req_header("cookie")
-  # %{"Cookie" => "xyz"}
-  %Conn{req_headers: %{"cookie" => {"Cookie", "xyz"}} |> get_req_header
+      iex> %Maxwell.Conn{req_headers: %{"cookie" => "xyz"} |> get_req_header
+      %{"cookie" => "xyz"}
   """
-  def get_req_header(conn, key \\ nil)
-  def get_req_header(%Conn{req_headers: headers}, nil) do
-    for {_, origin_header} <- headers, into: %{}, do: origin_header
+  @spec get_req_header(Conn.t) :: %{String.t => String.t}
+  def get_req_headers(%Conn{req_headers: headers}), do: headers
+
+  # TODO: Remove
+  @doc false
+  def get_req_header(conn) do
+    IO.warn "get_req_header/1 is deprecated, use get_req_headers/1 instead", System.stacktrace
+    get_req_headers(conn)
   end
-  def get_req_header(%Conn{req_headers: headers}, key), do: headers[key] || headers[String.downcase(key)]
 
   @doc """
-  Merge adapter's request options.
-
-   * `conn` - `%Conn{}`.
-   * `opts` - request's options, for example `[connect_timeout: 4000]`.
-   * `key_or_keyword` - for example: `:cookie` or `[cookie: "xyz"]`.
-   * `value` - for example: "xyz", only valid when `key_or_keyword` is a key.
+  Get a request header by key. The key lookup is case-insensitive.
+  Returns the value as a string, or nil if it doesn't exist.
 
   ### Examples
 
-      # %Conn{opts: [connect_timeout: 5000, cookie: "xyz"]}
-      %Conn{opts: [connect_timeout: 5000]} |> put_option('cookie', "xyz")
+      iex> %Maxwell.Conn{req_headers: %{"cookie" => "xyz"} |> get_req_header("cookie")
+      "xyz"
   """
-  def put_option(conn \\ %Conn{}, key_or_keyword, value \\ nil)
-  def put_option(conn = %Conn{state: :unsent, opts: opts}, key, value) do
-    new_opts = if value, do: [{key, value}], else: key
-    %{conn| opts: Keyword.merge(opts, new_opts)}
+  @spec get_req_header(Conn.t, String.t) :: String.t | nil
+  def get_req_header(conn, nil) do
+    IO.warn "get_req_header/2 with a nil key is deprecated, use get_req_headers/2 instead", System.stacktrace
+    get_req_headers(conn)
   end
-  def put_option(_conn, _key, _value), do: raise AlreadySentError
+  def get_req_header(%Conn{req_headers: headers}, key), do: Map.get(headers, String.downcase(key))
 
   @doc """
-  Replace req_body.
-
-    * `conn` - `%Conn{}`
-    * `req_body` - request's body iodata for example `"I Found You"`
+  Set adapter options for the request.
 
   ### Examples
-      # %Conn{req_body: "new body"}
-      %Conn{req_body: "old body"} |> body("new body")
+
+      iex> put_options(new(), connect_timeout: 4000)
+      %Maxwell.Conn{opts: [connect_timeout: 4000]}
   """
-  def put_req_body(conn \\ %Conn{}, req_body)
-  def put_req_body(conn = %Conn{state: :unsent}, req_body) do
-    %{conn| req_body: req_body}
+  @spec put_options(Conn.t, Keyword.t) :: Conn.t | no_return
+  def put_options(%Conn{state: :unsent, opts: opts} = conn, extra_opts) when is_list(extra_opts) do
+    %{conn | opts: Keyword.merge(opts, extra_opts)}
+  end
+  def put_options(_conn, extra_opts) when is_list(extra_opts), do: raise AlreadySentError
+
+  @doc """
+  Set an adapter option for the request.
+
+  ### Examples
+
+      iex> put_option(new(), :connect_timeout, 5000)
+      %Maxwell.Conn{opts: [connect_timeout: 5000]}
+  """
+  @spec put_option(Conn.t, atom(), term()) :: Conn.t | no_return
+  def put_option(%Conn{state: :unsent, opts: opts} = conn, key, value) when is_atom(key) do
+    %{conn | opts: [{key, value} | opts]}
+  end
+  def put_option(%Conn{}, key, _value) when is_atom(key), do: raise AlreadySentError
+
+  # TODO: remove
+  @doc false
+  def put_option(opts) when is_list(opts) do
+    IO.warn "put_option/1 is deprecated, use new/1 or new/2 followed by put_options/2 instead", System.stacktrace
+    put_options(new(), opts)
+  end
+
+  # TODO: remove
+  @doc false
+  def put_option(conn, opts) when is_list(opts) do
+    IO.warn "put_option/2 is deprecated, use put_options/2 instead", System.stacktrace
+    put_options(conn, opts)
+  end
+
+  @doc """
+  Set the request body.
+
+  ### Examples
+
+      iex> put_req_body(new(), "new body")
+      %Maxwell.Conn{req_body: "new_body"}
+  """
+  @spec put_req_body(Conn.t, Stream.t | binary()) :: Conn.t | no_return
+  def put_req_body(%Conn{state: :unsent} = conn, req_body) do
+    %{conn | req_body: req_body}
   end
   def put_req_body(_conn, _req_body), do: raise AlreadySentError
 
+  # TODO: remove
+  @doc false
+  def put_req_body(body) do
+    IO.warn "put_req_body/1 is deprecated, use new/1 or new/2 followed by put_req_body/2 instead", System.stacktrace
+    put_req_body(new(), body)
+  end
+
   @doc """
-  Get response status, raise `Maxwell.Conn.NotSentError` when request is unsent.
-  * `conn` - `%Conn{}`
+  Get response status.
+  Raises `Maxwell.Conn.NotSentError` when the request is unsent.
 
   ### Examples
 
-      # 200
-      %Conn{status: 200} |> get_status()
+      iex> get_status(%Maxwell.Conn{status: 200})
+      200
   """
-  def get_status(%Conn{status: status, state: state})when state !== :unsent, do: status
+  @spec get_status(Conn.t) :: pos_integer | no_return
+  def get_status(%Conn{status: status, state: state}) when state !== :unsent, do: status
   def get_status(_conn), do: raise NotSentError
 
   @doc """
-
-  * `get_resp_header/1` - get all response headers, return `Map.t`.
-  * `get_resp_header/2` - get response header by `key`, return value.
-  * `conn` - `%Conn{}`
+  Get all response headers as a map.
 
   ### Examples
 
-      # {"Cookie", "xyz"}
-      %Conn{resp_headers: %{"cookie" => {"Cookie", "xyz"}} |> get_resp_header("cookie")
-      # %{"Cookie" => "xyz"}
-      %Conn{resp_headers: %{"cookie" => {"Cookie", "xyz"}} |> get_resp_header
+      iex> %Maxwell.Conn{resp_headers: %{"cookie" => "xyz"} |> get_resp_header
+      %{"cookie" => "xyz"}
   """
-  def get_resp_header(conn, key \\ nil)
-  def get_resp_header(%Conn{state: :unsent}, _key), do: raise NotSentError
-  def get_resp_header(%Conn{resp_headers: headers}, nil) do
-    for {_, origin_header} <- headers, into: %{}, do: origin_header
+  @spec get_resp_headers(Conn.t) :: %{String.t => String.t} | no_return
+  def get_resp_headers(%Conn{state: :unsent}), do: raise NotSentError
+  def get_resp_headers(%Conn{resp_headers: headers}), do: headers
+
+  # TODO: remove
+  @doc false
+  def get_resp_header(conn) do
+    IO.warn "get_resp_header/1 is deprecated, use get_resp_headers/1 instead", System.stacktrace
+    get_resp_headers(conn)
   end
-  def get_resp_header(%Conn{resp_headers: headers}, key), do: headers[key] || headers[String.downcase(key)]
 
   @doc """
-  * `get_resp_body/1` - get all response body.
-  * `get_resp_body/2` - get response header by `key` or `func`(fn/1).
-  * `conn` - `%Conn{}`
+  Get a response header by key.
+  The value is returned as a string, or nil if the header is not set.
 
   ### Examples
 
-      # "best http client"
-      %Conn{resp_body: "best http client" |> get_resp_body
-      # "xyz"
-      %Conn{resp_body: %{"name" => "xyz"}} |> get_resp_body("name")
-      func = fn(x) ->
-          [key, value] = String.split(x, ":")
-          value
-      end
-      # "xyz"
-      %Conn{resp_body: "name:xyz" |> get_resp_body(func)
-
+      iex> %Maxwell.Conn{resp_headers: %{"cookie" => "xyz"}} |> get_resp_header("cookie")
+      "xyz"
   """
-  def get_resp_body(conn, func \\ nil)
-  def get_resp_body(%Conn{state: :unsent}, _keys), do: raise NotSentError
-  def get_resp_body(%Conn{resp_body: body}, nil), do: body
-  def get_resp_body(%Conn{resp_body: body}, func)when is_function(func, 1), do: func.(body)
-  def get_resp_body(%Conn{resp_body: body}, keys)when is_list(keys), do: get_in(body, keys)
+  @spec get_resp_header(Conn.t, String.t) :: String.t | nil | no_return
+  def get_resp_header(%Conn{state: :unsent}, _key), do: raise NotSentError
+  # TODO: remove
+  def get_resp_header(conn, nil) do
+    IO.warn "get_resp_header/2 with a nil key is deprecated, use get_resp_headers/1 instead", System.stacktrace
+    get_resp_headers(conn)
+  end
+  def get_resp_header(%Conn{resp_headers: headers}, key), do: Map.get(headers, String.downcase(key))
+
+  @doc """
+  Return the response body.
+
+  ### Examples
+
+      iex> get_resp_body(%Maxwell.Conn{state: :sent, resp_body: "best http client"})
+      "best http client"
+  """
+  @spec get_resp_body(Conn.t) :: binary() | map() | no_return
+  def get_resp_body(%Conn{state: :sent, resp_body: body}), do: body
+  def get_resp_body(_conn), do: raise NotSentError
+
+  @doc """
+  Return a value from the response body by key or with a parsing function.
+
+  ### Examples
+
+      iex> get_resp_body(%Maxwell.Conn{state: :sent, resp_body: %{"name" => "xyz"}}, "name")
+      "xyz"
+
+      iex> func = fn(x) ->
+      ...>   [key, value] = String.split(x, ":")
+      ...>   value
+      ...> end
+      ...> get_resp_body(%Maxwell.Conn{state: :sent, resp_body: "name:xyz"}, func)
+      "xyz"
+  """
+  def get_resp_body(%Conn{state: state}, _) when state != :sent,             do: raise NotSentError
+  def get_resp_body(%Conn{resp_body: body}, func) when is_function(func, 1), do: func.(body)
+  def get_resp_body(%Conn{resp_body: body}, keys) when is_list(keys),        do: get_in(body, keys)
   def get_resp_body(%Conn{resp_body: body}, key), do: body[key]
 
   defimpl Inspect, for: Conn do
@@ -317,6 +421,5 @@ defmodule Maxwell.Conn do
       Inspect.Any.inspect(conn, opts)
     end
   end
-
 end
 

--- a/lib/maxwell/middleware/header.ex
+++ b/lib/maxwell/middleware/header.ex
@@ -10,7 +10,9 @@ defmodule Maxwell.Middleware.Headers do
 
         def request do
           # headers is merge to %{'User-Agent' => "zhongwencool", 'username' => "zhongwencool"}
-          %{'username' => "zhongwencool"} |> put_req_header |> get!
+          new()
+          |> put_req_header(%{'username' => "zhongwencool"})
+          |> get!
         end
 
   """
@@ -19,11 +21,13 @@ defmodule Maxwell.Middleware.Headers do
 
   def init(headers) do
     check_headers(headers)
-    %Conn{} |> Conn.put_req_header(headers) |> Map.get(:req_headers)
+    Conn.new()
+    |> Conn.put_req_headers(headers)
+    |> Map.get(:req_headers)
   end
 
   def request(%Conn{} = conn, req_headers) do
-    %{conn | req_headers: Map.merge(req_headers, conn.req_headers)}
+    Conn.put_req_headers(conn, req_headers)
   end
 
   defp check_headers(headers) do

--- a/lib/maxwell/middleware/header_case.ex
+++ b/lib/maxwell/middleware/header_case.ex
@@ -1,0 +1,52 @@
+defmodule Maxwell.Middleware.HeaderCase do
+  @moduledoc """
+  Forces all request headers to be of a certain case.
+
+  ## Examples
+
+      # Lower
+      iex> conn = %Maxwell.Conn{req_headers: %{"content-type" => "application/json}}
+      ...> Maxwell.Middleware.HeaderCase.request(conn, :lower)
+      %Maxwell.Conn{req_headers: %{"content-type" => "application/json}}
+
+      # Upper
+      iex> conn = %Maxwell.Conn{req_headers: %{"content-type" => "application/json}}
+      ...> Maxwell.Middleware.HeaderCase.request(conn, :upper)
+      %Maxwell.Conn{req_headers: %{"CONTENT-TYPE" => "application/json}}
+
+      # Title
+      iex> conn = %Maxwell.Conn{req_headers: %{"content-type" => "application/json}}
+      ...> Maxwell.Middleware.HeaderCase.request(conn, :title)
+      %Maxwell.Conn{req_headers: %{"Content-Type" => "application/json}}
+  """
+  alias Maxwell.Conn
+  def init(casing) when casing in [:lower, :upper, :title] do
+    casing
+  end
+
+  def request(%Conn{req_headers: headers} = conn, :lower) do
+    new_headers = headers
+    |> Enum.map(fn {k, v} -> {String.downcase(k), v} end)
+    |> Enum.into(%{})
+    %{conn | req_headers: new_headers}
+  end
+  def request(%Conn{req_headers: headers} = conn, :upper) do
+    new_headers = headers
+    |> Enum.map(fn {k, v} -> {String.upcase(k), v} end)
+    |> Enum.into(%{})
+    %{conn | req_headers: new_headers}
+  end
+  def request(%Conn{req_headers: headers} = conn, :title) do
+    new_headers = headers
+    |> Enum.map(fn {k, v} ->
+      tk = k
+      |> String.downcase
+      |> String.split(~r/[-_]/, include_captures: true, trim: true)
+      |> Enum.map(&String.capitalize/1)
+      |> Enum.join
+      {tk, v}
+    end)
+    |> Enum.into(%{})
+    %{conn | req_headers: new_headers}
+  end
+end

--- a/test/maxwell/adapter/adapter_test_helper.exs
+++ b/test/maxwell/adapter/adapter_test_helper.exs
@@ -14,64 +14,56 @@ defmodule Maxwell.Adapter.TestHelper do
         middleware Maxwell.Middleware.Json
 
         def get_ip_test() do
-          "/ip" |> put_path |> get!
+          get!(new("/ip"))
         end
 
         def encode_decode_json_test(body) do
-          "/post"
-          |> put_path
+          new("/post")
           |> put_req_body(body)
           |> post!
           |> get_resp_body("json")
         end
 
         def user_agent_test(user_agent) do
-          "/user-agent"
-          |> put_path
+          new("/user-agent")
           |> put_req_header("user-agent", user_agent)
           |> get!
           |> get_resp_body("user-agent")
         end
 
         def put_json_test(json) do
-          "/put"
-          |> put_path
+          new("/put")
           |> put_req_body(json)
           |> put!
           |> get_resp_body("data")
         end
 
         def delete_test() do
-          "/delete"
-          |> put_path
+          new("/delete")
           |> delete!
           |> get_resp_body("data")
         end
 
         def multipart_test() do
-          "/post"
-          |> put_path
+          new("/post")
           |> put_req_body({:multipart, [{:file, "test/maxwell/multipart_test_file.sh"}]})
           |> post!
         end
         def multipart_with_extra_header_test() do
-          "/post"
-          |> put_path
+          new("/post")
           |> put_req_body({:multipart, [{:file, "test/maxwell/multipart_test_file.sh", [{"Content-Type", "image/jpeg"}]}]})
           |> post!
         end
 
         def file_test(filepath) do
-          "/post"
-          |> put_path
+          new("/post")
           |> put_req_header("transfer-encoding", "chunked")
           |> put_req_body({:file, filepath})
           |> post!
         end
 
         def file_test(filepath, content_type) do
-          "/post"
-          |> put_path
+          new("/post")
           |> put_req_header("transfer-encoding", "Chunked")
           |> put_req_body({:file, filepath})
           |> put_req_header("content-type", content_type)
@@ -79,16 +71,14 @@ defmodule Maxwell.Adapter.TestHelper do
         end
 
         def file_without_transfer_encoding_test(filepath, content_type) do
-          "/post"
-          |> put_path
+          new("/post")
           |> put_req_body({:file, filepath})
           |> put_req_header("content-type", content_type)
           |> post!
         end
 
         def stream_test() do
-          "/post"
-          |> put_path
+          new("/post")
           |> put_req_header("content-type", "application/vnd.lotus-1-2-3")
           |> put_req_header("content-length", 6)
           |> put_req_body(Stream.map(["1", "2", "3"], fn(x) -> List.duplicate(x, 2) end))
@@ -163,8 +153,6 @@ defmodule Maxwell.Adapter.TestHelper do
         assert body == ""
       end
     end
-
   end
-
 end
 

--- a/test/maxwell/adapter/hackney_test.exs
+++ b/test/maxwell/adapter/hackney_test.exs
@@ -17,70 +17,60 @@ defmodule Maxwell.HackneyMockTest do
     middleware Maxwell.Middleware.Json
 
     def get_ip_test do
-      put_path("/ip")
-      |> get!
+      get!(new("/ip"))
     end
     def encode_decode_json_test(body) do
-      "/post"
-      |> put_path
+      new("/post")
       |> put_req_body(body)
       |> post!
       |> get_resp_body("json")
     end
 
     def user_agent_test(user_agent) do
-      "/user-agent"
-      |> put_path
+      new("/user-agent")
       |> put_req_header("user-agent", user_agent)
       |> get!
       |> get_resp_body("user-agent")
     end
 
     def put_json_test(json) do
-      "/put"
-      |> put_path
+      new("/put")
       |> put_req_body(json)
       |> put!
       |> get_resp_body("data")
     end
 
     def delete_test() do
-      "/delete"
-      |> put_path
+      new("/delete")
       |> delete!
       |> get_resp_body("data")
     end
 
     def timeout_test() do
-      "/delay/5"
-      |> put_path
+      new("/delay/5")
       |> put_option(:recv_timeout, 1000)
       |> Client.get
     end
 
     def multipart_test() do
-      "/post"
-      |> put_path
+      new("/post")
       |> put_req_body({:multipart, [{:file, "test/maxwell/multipart_test_file.sh"}]})
       |> Client.post!
     end
     def multipart_with_extra_header_test() do
-      "/post"
-      |> put_path
+      new("/post")
       |> put_req_body({:multipart, [{:file, "test/maxwell/multipart_test_file.sh", [{"Content-Type", "image/jpeg"}]}]})
       |> Client.post!
     end
 
     def file_test() do
-      "/post"
-      |> put_path
+      new("/post")
       |> put_req_body({:file, "test/maxwell/multipart_test_file.sh"})
       |> Client.post!
     end
 
     def stream_test() do
-      "/post"
-      |> put_path
+      new("/post")
       |> put_req_body(Stream.map(["1", "2", "3"], fn(x) -> List.duplicate(x, 2) end))
       |> Client.post!
     end
@@ -120,7 +110,7 @@ defmodule Maxwell.HackneyMockTest do
         {"Connection", "keep-alive"}, {"Access-Control-Allow-Origin", "*"},
         {"Access-Control-Allow-Credentials", "true"}], make_ref()}
     end,
-     body: fn(_) -> {:ok,
+     body: fn _ -> {:ok,
                      "{\n  \"args\": {}, \n  \"data\": \"{\\\"josnkey2\\\":\\\"jsonvalue2\\\",\\\"josnkey1\\\":\\\"jsonvalue1\\\"}\", \n  \"files\": {}, \n  \"form\": {}, \n  \"headers\": {\n    \"Content-Length\": \"49\", \n    \"Content-Type\": \"application/json\", \n    \"Host\": \"httpbin.org\", \n    \"User-Agent\": \"hackney/1.6.3\"\n  }, \n  \"json\": {\n    \"josnkey1\": \"jsonvalue1\", \n    \"josnkey2\": \"jsonvalue2\"\n  }, \n  \"origin\": \"183.240.20.213\", \n  \"url\": \"http://httpbin.org/post\"\n}\n"}
      end
     ] do
@@ -136,7 +126,7 @@ defmodule Maxwell.HackneyMockTest do
         {"Content-Type", "application/json"}, {"Content-Length", "428"},
         {"Connection", "keep-alive"}, {"Access-Control-Allow-Origin", "*"},
         {"Access-Control-Allow-Credentials", "true"}], make_ref()} end,
-     body: fn(_) -> {:ok,
+     body: fn _ -> {:ok,
                      "{\n  \"args\": {}, \n  \"data\": \"\", \n  \"files\": {\n    \"file\": \"#!/usr/bin/env bash\\necho \\\"test multipart file\\\"\\n\"\n  }, \n  \"form\": {}, \n  \"headers\": {\n    \"Content-Length\": \"279\", \n    \"Content-Type\": \"multipart/form-data; boundary=---------------------------tvvbujkbhrbruqcy\", \n    \"Host\": \"httpbin.org\", \n    \"User-Agent\": \"hackney/1.6.3\"\n  }, \n  \"json\": null, \n  \"origin\": \"183.240.20.213\", \n  \"url\": \"http://httpbin.org/post\"\n}\n"}
      end ] do
     conn = Client.multipart_test
@@ -150,7 +140,7 @@ defmodule Maxwell.HackneyMockTest do
         {"Content-Type", "application/json"}, {"Content-Length", "428"},
         {"Connection", "keep-alive"}, {"Access-Control-Allow-Origin", "*"},
         {"Access-Control-Allow-Credentials", "true"}], make_ref()}
-    end, body: fn(_) ->
+    end, body: fn _ ->
       {:ok,
        "{\n  \"args\": {}, \n  \"data\": \"\", \n  \"files\": {\n    \"file\": \"#!/usr/bin/env bash\\necho \\\"test multipart file\\\"\\n\"\n  }, \n  \"form\": {}, \n  \"headers\": {\n    \"Content-Length\": \"273\", \n    \"Content-Type\": \"multipart/form-data; boundary=---------------------------dlhrimiytrrvmxqk\", \n    \"Host\": \"httpbin.org\", \n    \"User-Agent\": \"hackney/1.6.3\"\n  }, \n  \"json\": null, \n  \"origin\": \"183.240.20.213\", \n  \"url\": \"http://httpbin.org/post\"\n}\n"}
     end ] do
@@ -166,7 +156,7 @@ defmodule Maxwell.HackneyMockTest do
         {"Connection", "keep-alive"}, {"Access-Control-Allow-Origin", "*"},
         {"Access-Control-Allow-Credentials", "true"}], make_ref()}
     end,
-     body: fn(_) ->
+     body: fn _ ->
        {:ok,
         "{\n  \"args\": {}, \n  \"data\": \"#!/usr/bin/env bash\\necho \\\"test multipart file\\\"\\n\", \n  \"files\": {}, \n  \"form\": {}, \n  \"headers\": {\n    \"Content-Length\": \"47\", \n    \"Content-Type\": \"application/x-sh\", \n    \"Host\": \"httpbin.org\", \n    \"User-Agent\": \"hackney/1.6.3\"\n  }, \n  \"json\": null, \n  \"origin\": \"183.240.20.213\", \n  \"url\": \"http://httpbin.org/post\"\n}\n"}
      end ] do
@@ -178,15 +168,15 @@ defmodule Maxwell.HackneyMockTest do
     [request: fn(_,_,_,_,_) ->
       {:ok, make_ref()}
     end,
-     send_body: fn(_, _) -> :ok end,
-     start_response: fn(_) ->
+     send_body: fn _,_ -> :ok end,
+     start_response: fn _ ->
        {:ok, 200,
         [{"Server", "nginx"}, {"Date", "Sun, 18 Dec 2016 03:47:26 GMT"},
          {"Content-Type", "application/json"}, {"Content-Length", "267"},
          {"Connection", "keep-alive"}, {"Access-Control-Allow-Origin", "*"},
          {"Access-Control-Allow-Credentials", "true"}], make_ref()}
      end,
-     body: fn(_) ->
+     body: fn _ ->
        {:ok,
         "{\n  \"args\": {}, \n  \"data\": \"112233\", \n  \"files\": {}, \n  \"form\": {}, \n  \"headers\": {\n    \"Content-Length\": \"6\", \n    \"Host\": \"httpbin.org\", \n    \"User-Agent\": \"hackney/1.6.3\"\n  }, \n  \"json\": 112233, \n  \"origin\": \"183.240.20.213\", \n  \"url\": \"http://httpbin.org/post\"\n}\n"}
      end ] do
@@ -195,14 +185,14 @@ defmodule Maxwell.HackneyMockTest do
   end
 
   test_with_mock "send stream error", :hackney,
-    [request: fn(_,_,_,_,_) -> {:error, :closed} end,
-     send_body: fn(_, _) -> {:error, :closed} end,
-     start_response: fn(_) -> {:ok, 200, [], make_ref()} end,
-     body: fn(_) -> {:ok, "error connection closed"}
+    [request: fn _,_,_,_,_ -> {:error, :closed} end,
+     send_body: fn _,_ -> {:error, :closed} end,
+     start_response: fn _ -> {:ok, 200, [], make_ref()} end,
+     body: fn _ -> {:ok, "error connection closed"}
      end ] do
     assert_raise(Maxwell.Error,
       "url: http://httpbin.org\npath: \"/post\"\nmethod: post\nstatus: \nreason: :closed\nmodule: Elixir.Maxwell.HackneyMockTest.Client\n",
-      fn() -> Client.stream_test |> get_resp_body("data")  end)
+      fn -> Client.stream_test |> get_resp_body("data")  end)
   end
 
   test_with_mock "user-agent header test", :hackney,
@@ -213,20 +203,20 @@ defmodule Maxwell.HackneyMockTest do
         {"Connection", "keep-alive"}, {"Access-Control-Allow-Origin", "*"},
         {"Access-Control-Allow-Credentials", "true"}], make_ref()}
     end,
-     body: fn(_) ->
+     body: fn _ ->
        {:ok, "{\n  \"user-agent\": \"test\"\n}\n"}
      end ] do
     assert "test" |> Client.user_agent_test == "test"
   end
 
   test_with_mock "/put", :hackney,
-    [request: fn(_,_,_,_,_) ->
+    [request: fn _,_,_,_,_ ->
       {:ok, 200,
        [{"Server", "nginx"}, {"Date", "Sun, 18 Dec 2016 03:54:56 GMT"},
         {"Content-Type", "application/json"}, {"Content-Length", "339"},
         {"Connection", "keep-alive"}, {"Access-Control-Allow-Origin", "*"},
         {"Access-Control-Allow-Credentials", "true"}], make_ref()}
-    end, body: fn(_) ->
+    end, body: fn _ ->
       {:ok,
        "{\n  \"args\": {}, \n  \"data\": \"{\\\"key\\\":\\\"value\\\"}\", \n  \"files\": {}, \n  \"form\": {}, \n  \"headers\": {\n    \"Content-Length\": \"15\", \n    \"Content-Type\": \"application/json\", \n    \"Host\": \"httpbin.org\", \n    \"User-Agent\": \"hackney/1.6.3\"\n  }, \n  \"json\": {\n    \"key\": \"value\"\n  }, \n  \"origin\": \"183.240.20.213\", \n  \"url\": \"http://httpbin.org/put\"\n}\n"}
     end ] do
@@ -234,13 +224,13 @@ defmodule Maxwell.HackneyMockTest do
   end
 
   test_with_mock "/delete", :hackney,
-    [request: fn(_,_,_,_,_) ->
+    [request: fn _,_,_,_,_ ->
       {:ok, 200,
        [{"Server", "nginx"}, {"Date", "Sun, 18 Dec 2016 03:53:52 GMT"},
         {"Content-Type", "application/json"}, {"Content-Length", "233"},
         {"Connection", "keep-alive"}, {"Access-Control-Allow-Origin", "*"},
         {"Access-Control-Allow-Credentials", "true"}], make_ref()}
-    end, body: fn(_) ->
+    end, body: fn _ ->
       {:ok,
        "{\n  \"args\": {}, \n  \"data\": \"\", \n  \"files\": {}, \n  \"form\": {}, \n  \"headers\": {\n    \"Host\": \"httpbin.org\", \n    \"User-Agent\": \"hackney/1.6.3\"\n  }, \n  \"json\": null, \n  \"origin\": \"183.240.20.213\", \n  \"url\": \"http://httpbin.org/delete\"\n}\n"}
     end ] do
@@ -248,28 +238,28 @@ defmodule Maxwell.HackneyMockTest do
   end
 
   test_with_mock "/delete error", :hackney,
-    [request: fn(_,_,_,_,_) ->
+    [request: fn _,_,_,_,_ ->
       {:ok, 200,
        [{"Server", "nginx"}, {"Date", "Sun, 18 Dec 2016 03:53:52 GMT"},
         {"Content-Type", "application/json"}, {"Content-Length", "233"},
         {"Connection", "keep-alive"}, {"Access-Control-Allow-Origin", "*"},
         {"Access-Control-Allow-Credentials", "true"}], make_ref()}
-    end, body: fn(_) ->
+    end, body: fn _ ->
       {:error, {:closed, ""}}
     end ] do
     assert_raise(Maxwell.Error,
       "url: http://httpbin.org\npath: \"/delete\"\nmethod: delete\nstatus: \nreason: {:closed, \"\"}\nmodule: Elixir.Maxwell.HackneyMockTest.Client\n",
-      fn() -> Client.delete_test end)
+      fn -> Client.delete_test end)
   end
 
   test_with_mock "adapter return error", :hackney,
-    [request: fn(_,_,_,_,_) -> {:error, :timeout} end] do
+    [request: fn _,_,_,_,_ -> {:error, :timeout} end] do
     {:error, :timeout, conn} = Client.timeout_test
     assert conn.state == :error
   end
 
   test_with_mock "Head without body(test hackney.ex return {:ok, status, header})", :hackney,
-    [request: fn(_,_,_,_,_) ->
+    [request: fn _,_,_,_,_ ->
       {:ok, 200,
        [{"Server", "nginx"}, {"Date", "Sun, 18 Dec 2016 03:57:09 GMT"},
         {"Content-Type", "text/html; charset=utf-8"}, {"Content-Length", "12150"},
@@ -278,6 +268,5 @@ defmodule Maxwell.HackneyMockTest do
     end] do
     assert Client.head! |> get_resp_body == ""
   end
-
 end
 

--- a/test/maxwell/adapter/httpc_test.exs
+++ b/test/maxwell/adapter/httpc_test.exs
@@ -16,85 +16,72 @@ defmodule Maxwell.HttpcMockTest do
     middleware Maxwell.Middleware.Json
 
     def get_ip_test() do
-      "/ip" |> put_path |> Client.get!
+      Client.get!(new("/ip"))
     end
 
     def encode_decode_json_test(body) do
-      "/post"
-      |> put_path
+      new("/post")
       |> put_req_body(body)
       |> post!
       |> get_resp_body("json")
     end
 
     def user_agent_test(user_agent) do
-      "/user-agent"
-      |> put_path
+      new("/user-agent")
       |> put_req_header("user-agent", user_agent)
       |> get!
       |> get_resp_body("user-agent")
     end
 
     def put_json_test(json) do
-      "/put"
-      |> put_path
+      new("/put")
       |> put_req_body(json)
       |> put!
       |> get_resp_body("data")
     end
 
     def delete_test() do
-      "/delete"
-      |> put_path
+      new("/delete")
       |> delete!
       |> get_resp_body("data")
     end
 
     def normalized_error_test() do
-      "/"
-      |> put_path
-      |> Map.put(:url, "http://broken.local")
-      |> get
+      get(new("http://broken.local"))
     end
 
     def timeout_test() do
-      "/delay/2"
-      |> put_path
+      new("/delay/2")
       |> put_option(:timeout, 1000)
       |> Client.get
     end
 
     def multipart_test() do
-      "/post"
-      |> put_path
+      new("/post")
       |> put_req_body({:multipart, [{:file, "test/maxwell/multipart_test_file.sh"}]})
       |> Client.post!
     end
     def multipart_with_extra_header_test() do
-      "/post"
-      |> put_path
+      new("/post")
       |> put_req_body({:multipart, [{:file, "test/maxwell/multipart_test_file.sh", [{"Content-Type", "image/jpeg"}]}]})
       |> Client.post!
     end
 
     def file_test(filepath) do
-      "/post"
-      |> put_path
+      new("/post")
       |> put_req_body({:file, filepath})
       |> Client.post!
     end
 
     def file_test(filepath, content_type) do
-      "/post"
-      |> put_path
+      new("/post")
       |> put_req_body({:file, filepath})
       |> put_req_header("content-type", content_type)
       |> Client.post!
     end
 
     def stream_test() do
-      "/post"
-      |> put_path
+      new("/post")
       |> put_req_header("content-type", "application/vnd.lotus-1-2-3")
       |> put_req_header("content-length", 6)
       |> put_req_body(Stream.map(["1", "2", "3"], fn(x) -> List.duplicate(x, 2) end))
@@ -289,6 +276,5 @@ defmodule Maxwell.HttpcMockTest do
     {:error, :timeout, conn} = Client.timeout_test
     assert conn.state == :error
   end
-
 end
 

--- a/test/maxwell/adapter/ibrowse_test.exs
+++ b/test/maxwell/adapter/ibrowse_test.exs
@@ -16,92 +16,79 @@ defmodule Maxwell.IbrowseMockTest do
     middleware Maxwell.Middleware.Json
 
     def get_ip_test() do
-      "/ip" |> put_path |> Client.get!
+      new("/ip") |> Client.get!
     end
 
     def encode_decode_json_test(body) do
-      "/post"
-      |> put_path
+      new("/post")
       |> put_req_body(body)
       |> post!
       |> get_resp_body("json")
     end
 
     def user_agent_test(user_agent) do
-      "/user-agent"
-      |> put_path
+      new("/user-agent")
       |> put_req_header("user-agent", user_agent)
       |> get!
       |> get_resp_body("user-agent")
     end
 
     def put_json_test(json) do
-      "/put"
-      |> put_path
+      new("/put")
       |> put_req_body(json)
       |> put!
       |> get_resp_body("data")
     end
 
     def delete_test() do
-      "/delete"
-      |> put_path
+      new("/delete")
       |> delete!
       |> get_resp_body("data")
     end
 
     def normalized_error_test() do
-      "/"
-      |> put_path
-      |> Map.put(:url, "http://broken.local")
+      new("http://broken.local")
       |> get
     end
 
     def timeout_test() do
-      "/delay/5"
-      |> put_path
+      new("/delay/5")
       |> put_query_string("foo", "bar")
       |> put_option(:inactivity_timeout, 1000)
       |> Client.get
     end
 
     def multipart_test() do
-      "/post"
-      |> put_path
+      new("/post")
       |> put_req_body({:multipart, [{:file, "test/maxwell/multipart_test_file.sh"}]})
       |> Client.post!
     end
     def multipart_with_extra_header_test() do
-      "/post"
-      |> put_path
+      new("/post")
       |> put_req_body({:multipart, [{:file, "test/maxwell/multipart_test_file.sh", [{"Content-Type", "image/jpeg"}]}]})
       |> Client.post!
     end
 
     def file_test(filepath) do
-      "/post"
-      |> put_path
+      new("/post")
       |> put_req_body({:file, filepath})
       |> Client.post!
     end
 
     def file_test(filepath, content_type) do
-      "/post"
-      |> put_path
+      new("/post")
       |> put_req_body({:file, filepath})
       |> put_req_header("content-type", content_type)
       |> Client.post!
     end
 
     def stream_test() do
-      "/post"
-      |> put_path
+      new("/post")
       |> put_req_header("content-type", "application/vnd.lotus-1-2-3")
       |> put_req_header("content-length", 6)
       |> put_req_body(Stream.map(["1", "2", "3"], fn(x) -> List.duplicate(x, 2) end))
       |> Client.post!
     end
-
   end
 
   if Code.ensure_loaded?(:rand) do
@@ -141,7 +128,6 @@ defmodule Maxwell.IbrowseMockTest do
      end] do
     result = %{"josnkey1" => "jsonvalue1", "josnkey2" => "jsonvalue2"} |> Client.encode_decode_json_test
     assert result == %{"josnkey1" => "jsonvalue1", "josnkey2" => "jsonvalue2"}
-
   end
 
   test_with_mock "mutilpart body file", :ibrowse,
@@ -288,6 +274,5 @@ defmodule Maxwell.IbrowseMockTest do
     {:error, :req_timedout, conn} = Client.timeout_test
     assert conn.state == :error
   end
-
 end
 

--- a/test/maxwell/conn_test.exs
+++ b/test/maxwell/conn_test.exs
@@ -18,46 +18,58 @@ defmodule ConnTest do
     end
   end
 
-  test "put_query_string/2 put_query_string/3 test" do
-    assert put_query_string(%Conn{}, "name", "foo") == %Conn{state: :unsent, query_string: %{"name" => "foo"}}
-    assert put_query_string(%Conn{state: :unsent}, "name", "foo") == %Conn{state: :unsent, query_string: %{"name" => "foo"}}
-    assert put_query_string(%{"name" => "foo", "passwd" => "123"})
-    == %Conn{state: :unsent, query_string: %{"name" => "foo", "passwd" => "123"}}
-
+  test "put_query_string/2" do
+    assert put_query_string(new(), %{"name" => "foo", "passwd" => "123"})
+      == %Conn{state: :unsent, query_string: %{"name" => "foo", "passwd" => "123"}}
     assert_raise AlreadySentError, "the request was already sent", fn ->
       put_query_string(%Conn{state: :sent}, %{"name" => "foo"})
     end
+  end
+
+  test "put_query_string/3" do
+    assert put_query_string(%Conn{}, "name", "foo") == %Conn{state: :unsent, query_string: %{"name" => "foo"}}
+    assert put_query_string(%Conn{state: :unsent}, "name", "foo") == %Conn{state: :unsent, query_string: %{"name" => "foo"}}
+
     assert_raise AlreadySentError, "the request was already sent", fn ->
       put_query_string(%Conn{state: :sent}, "name", "foo")
     end
   end
 
-  test "put_req_header/2 put_req_header/3 test" do
-    assert put_req_header(%Conn{}, "cache-control", "no-cache")
-    assert put_req_header(%Conn{state: :unsent}, "cache-control", "no-cache")
-    == %Conn{state: :unsent, req_headers: %{"cache-control" => {"cache-control", "no-cache"}}}
-    assert put_req_header(%{"cache-control" => "no-cache", "ETag" => "rFjdsDtv2qxk7K1CwG4VMlF836E="})
-    == %Conn{state: :unsent, req_headers: %{"cache-control" => {"cache-control", "no-cache"},
-                                            "etag" => {"ETag", "rFjdsDtv2qxk7K1CwG4VMlF836E="}}}
-    assert put_req_header(%{"cache-control" => {"cache-control", "no-cache"}, "ETag" => "rFjdsDtv2qxk7K1CwG4VMlF836E="})
-    == %Conn{state: :unsent, req_headers: %{"cache-control" => {"cache-control", "no-cache"},
-                                            "etag" => {"ETag", "rFjdsDtv2qxk7K1CwG4VMlF836E="}}}
-
+  test "put_req_headers/2" do
+    assert put_req_headers(new(), %{"cache-control" => "no-cache", "ETag" => "rFjdsDtv2qxk7K1CwG4VMlF836E="})
+      == %Conn{state: :unsent, req_headers: %{"cache-control" => "no-cache",
+                                              "etag" => "rFjdsDtv2qxk7K1CwG4VMlF836E="}}
+    assert put_req_headers(new(), %{"cache-control" => "no-cache", "ETag" => "rFjdsDtv2qxk7K1CwG4VMlF836E="})
+      == %Conn{state: :unsent, req_headers: %{"cache-control" => "no-cache",
+                                              "etag" => "rFjdsDtv2qxk7K1CwG4VMlF836E="}}
     assert_raise AlreadySentError, "the request was already sent", fn ->
-      put_req_header(%Conn{state: :sent}, %{"cache-control" => "no-cache"})
+      put_req_headers(%Conn{state: :sent}, %{"cache-control" => "no-cache"})
     end
+  end
+
+  test "put_req_header/3" do
+    assert put_req_header(new(), "cache-control", "no-cache")
+    assert put_req_header(new(), "cache-control", "no-cache")
+      == %Conn{state: :unsent, req_headers: %{"cache-control" => "no-cache"}}
+
     assert_raise AlreadySentError, "the request was already sent", fn ->
       put_req_header(%Conn{state: :sent}, "cache-control", "no-cache")
     end
   end
 
-  test "put_option/2 put_option/3 test" do
+  test "put_options/2" do
+    conn = put_options(%Conn{state: :unsent, opts: [max_attempts: 3]}, connect_timeout: 3000)
+    assert Keyword.equal?(conn.opts, [connect_timeout: 3000, max_attempts: 3])
+    assert_raise AlreadySentError, "the request was already sent", fn ->
+      put_options(%Conn{state: :sent}, connect_timeout: 3000)
+    end
+  end
+
+  test "put_option/3" do
     conn0 = put_option(%Conn{state: :unsent, opts: [max_attempts: 3]}, :connect_timeout, 3000)
     assert Keyword.equal?(conn0.opts, [connect_timeout: 3000, max_attempts: 3])
     conn1 = put_option(%Conn{state: :unsent, opts: [max_attempts: 3]}, :connect_timeout, 3000)
     assert Keyword.equal?(conn1.opts, [connect_timeout: 3000, max_attempts: 3])
-    conn2 = put_option(%Conn{state: :unsent, opts: [max_attempts: 3]}, [connect_timeout: 3000])
-    assert Keyword.equal?(conn2.opts, [connect_timeout: 3000, max_attempts: 3])
     assert_raise AlreadySentError, "the request was already sent", fn ->
       put_option(%Conn{state: :sent}, :connect_timeout, 3000)
     end
@@ -77,36 +89,52 @@ defmodule ConnTest do
     end
   end
 
-  test "get_resp_header/2 get_resp_header/3 test" do
-    assert get_resp_header(%Conn{state: :sent, resp_headers: %{"server" => {"Server", "Microsoft-IIS/8.5"}}})
-    == %{"Server" => "Microsoft-IIS/8.5"}
-    assert get_resp_header(%Conn{state: :sent, resp_headers: %{"server" => {"Server", "Microsoft-IIS/8.5"}}}, "Server")
-    == {"Server", "Microsoft-IIS/8.5"}
-    assert get_resp_header(%Conn{state: :sent, resp_headers: %{"server" => {"Server", "Microsoft-IIS/8.5"}}}, "Server1")
-    == nil
+  test "get_resp_headers/1" do
+    assert get_resp_headers(%Conn{state: :sent, resp_headers: %{"server" => "Microsoft-IIS/8.5"}})
+      == %{"server" => "Microsoft-IIS/8.5"}
+    assert_raise NotSentError, "the request was not sent yet", fn ->
+      get_resp_headers(%Conn{state: :unsent})
+    end
+  end
+
+  test "get_resp_header/2" do
+    assert get_resp_header(%Conn{state: :sent, resp_headers: %{"server" => "Microsoft-IIS/8.5"}}, "Server")
+      == "Microsoft-IIS/8.5"
+    assert get_resp_header(%Conn{state: :sent, resp_headers: %{"server" => "Microsoft-IIS/8.5"}}, "Server1")
+      == nil
     assert_raise NotSentError, "the request was not sent yet", fn ->
       get_resp_header(%Conn{state: :unsent}, "Server")
     end
   end
 
-  test "get_req_header/2 get_req_header/3 test" do
-    assert get_req_header(%Conn{req_headers: %{"server" => {"Server", "Microsoft-IIS/8.5"}}})
-    == %{"Server" => "Microsoft-IIS/8.5"}
-    assert get_req_header(%Conn{req_headers: %{"server" => {"Server", "Microsoft-IIS/8.5"}}}, "Server")
-    == {"Server", "Microsoft-IIS/8.5"}
-    assert get_req_header(%Conn{req_headers: %{"server" => {"Server", "Microsoft-IIS/8.5"}}}, "Server1")
-    == nil
+  test "get_req_headers/1" do
+    assert get_req_headers(%Conn{req_headers: %{"server" => "Microsoft-IIS/8.5"}})
+      == %{"server" => "Microsoft-IIS/8.5"}
   end
 
-  test "get_resp_body/2 get_resp_body/3 test" do
+  test "get_req_header/2" do
+    assert get_req_header(%Conn{req_headers: %{"server" => "Microsoft-IIS/8.5"}}, "Server")
+      == "Microsoft-IIS/8.5"
+    assert get_req_header(%Conn{req_headers: %{"server" => "Microsoft-IIS/8.5"}}, "Server1")
+      == nil
+  end
+
+  test "get_resp_body/1" do
     assert get_resp_body(%Conn{state: :sent, resp_body: "I'm ok"}) ==  "I'm ok"
-    assert get_resp_body(%Conn{state: :sent, resp_body: %{"foo" => %{"addr" => "China"}}}, ["foo", "addr"]) == "China"
-    func = fn(body) -> String.split(body, ~r{,}) end
-    assert get_resp_body(%Conn{state: :sent, resp_body: "1,2,3"}, func) == ["1", "2", "3"]
     assert_raise NotSentError, "the request was not sent yet", fn ->
       get_resp_body(%Conn{state: :unsent})
     end
   end
 
+  test "get_resp_body/2" do
+    assert get_resp_body(%Conn{state: :sent, resp_body: %{"foo" => %{"addr" => "China"}}}, ["foo", "addr"]) == "China"
+
+    func = fn(body) -> String.split(body, ~r{,}) end
+    assert get_resp_body(%Conn{state: :sent, resp_body: "1,2,3"}, func) == ["1", "2", "3"]
+
+    assert_raise NotSentError, "the request was not sent yet", fn ->
+      get_resp_body(%Conn{state: :unsent, resp_body: %{"foo" => "bar"}}, "foo")
+    end
+  end
 end
 

--- a/test/maxwell/middleware/fuse_test.exs
+++ b/test/maxwell/middleware/fuse_test.exs
@@ -29,20 +29,20 @@ defmodule FuseTest do
   end
 
   test "regular endpoint" do
-    assert Conn.put_path("/ok") |> Client.get! |> Conn.get_resp_body() == "ok"
+    assert Conn.new("/ok") |> Client.get! |> Conn.get_resp_body() == "ok"
   end
 
   test "unavailable endpoint" do
-    assert_raise Maxwell.Error, fn -> Conn.put_path("/unavailable") |> Client.get! end
+    assert_raise Maxwell.Error, fn -> Conn.new("/unavailable") |> Client.get! end
     assert_receive :request_made
-    assert_raise Maxwell.Error, fn -> Conn.put_path("/unavailable") |> Client.get! end
+    assert_raise Maxwell.Error, fn -> Conn.new("/unavailable") |> Client.get! end
     assert_receive :request_made
-    assert_raise Maxwell.Error, fn -> Conn.put_path("/unavailable") |> Client.get! end
+    assert_raise Maxwell.Error, fn -> Conn.new("/unavailable") |> Client.get! end
     assert_receive :request_made
 
-    assert_raise Maxwell.Error, fn -> Conn.put_path("/unavailable") |> Client.get! end
+    assert_raise Maxwell.Error, fn -> Conn.new("/unavailable") |> Client.get! end
     refute_receive :request_made
-    assert_raise Maxwell.Error, fn -> Conn.put_path("/unavailable") |> Client.get! end
+    assert_raise Maxwell.Error, fn -> Conn.new("/unavailable") |> Client.get! end
     refute_receive :request_made
   end
 end

--- a/test/maxwell/middleware/header_case_test.exs
+++ b/test/maxwell/middleware/header_case_test.exs
@@ -1,0 +1,32 @@
+defmodule HeaderCaseTest do
+  use ExUnit.Case, async: true
+
+  import Maxwell.Middleware.TestHelper
+  alias Maxwell.Conn
+
+  test "lower case" do
+    conn = %Conn{req_headers: %{"Content-Type" => "application/json"}}
+    conn = request(Maxwell.Middleware.HeaderCase, conn, :lower)
+    assert conn.req_headers == %{"content-type" => "application/json"}
+  end
+
+  test "upper case" do
+    conn = %Conn{req_headers: %{"Content-Type" => "application/json"}}
+    conn = request(Maxwell.Middleware.HeaderCase, conn, :upper)
+    assert conn.req_headers == %{"CONTENT-TYPE" => "application/json"}
+  end
+
+  test "title case" do
+    conn = %Conn{req_headers: %{"content-type" => "application/json"}}
+    conn = request(Maxwell.Middleware.HeaderCase, conn, :title)
+    assert conn.req_headers == %{"Content-Type" => "application/json"}
+
+    conn = %Conn{req_headers: %{"CONTENT-TYPE" => "application/json"}}
+    conn = request(Maxwell.Middleware.HeaderCase, conn, :title)
+    assert conn.req_headers == %{"Content-Type" => "application/json"}
+
+    conn = %Conn{req_headers: %{"Content-Type" => "application/json"}}
+    conn = request(Maxwell.Middleware.HeaderCase, conn, :title)
+    assert conn.req_headers == %{"Content-Type" => "application/json"}
+  end
+end

--- a/test/maxwell/middleware/header_test.exs
+++ b/test/maxwell/middleware/header_test.exs
@@ -3,22 +3,18 @@ defmodule HeaderTest do
   import Maxwell.Middleware.TestHelper
 
   alias Maxwell.Conn
-  test "Base Middleware Headers" do
+  test "sets default request headers" do
     conn =
-      request(Maxwell.Middleware.Headers,
-        %Conn{req_headers: %{}},
-        %{"content-type" => {"Content-Type", "text/plain"}})
-    assert conn.req_headers == %{"content-type" => {"Content-Type", "text/plain"}}
+      request(Maxwell.Middleware.Headers, Conn.new(), %{"content-type" => "text/plain"})
+    assert conn.req_headers == %{"content-type" => "text/plain"}
   end
 
-  test "Replace Middleware Headers" do
-    conn = request(Maxwell.Middleware.Headers,
-      %Conn{req_headers: %{"content-type" => {"Content-Type", "application/json"}}},
-      %{"content-type" => {"Content-Type", "text/plain"}})
-    assert conn.req_headers == %{"content-type" => {"Content-Type", "application/json"}}
+  test "overrides request headers" do
+    conn = request(Maxwell.Middleware.Headers, %Conn{req_headers: %{"content-type" => "application/json"}}, %{"content-type" => "text/plain"})
+    assert conn.req_headers == %{"content-type" => "text/plain"}
   end
 
-  test "header key is not string" do
+  test "raises an error if header key is not a string" do
     assert_raise ArgumentError, "Header keys must be strings, but got: %{key: \"value\"}", fn ->
       defmodule TAtom111 do
         use Maxwell.Builder, [:get, :post]
@@ -27,6 +23,5 @@ defmodule HeaderTest do
       raise "ok"
     end
   end
-
 end
 

--- a/test/maxwell/middleware/middleware_test.exs
+++ b/test/maxwell/middleware/middleware_test.exs
@@ -6,10 +6,10 @@ defmodule MiddlewareTest do
       conn = %{conn| state: :sent}
       body = unless conn.req_body, do: %{}, else: Poison.decode!(conn.req_body)
       if Map.equal?(body, %{"key2" => 101, "key1" => 201}) do
-        %{conn| status: 200, resp_headers: %{"content-type" => {"Content-Type", "application/json"}},
+        %{conn| status: 200, resp_headers: %{"content-type" => "application/json"},
                 resp_body: "{\"key2\":101,\"key1\":201}"}
       else
-        %{conn| status: 200, resp_headers: %{"content-type" => {"Content-Type", "application/json"}},
+        %{conn| status: 200, resp_headers: %{"content-type" => "application/json"},
                 resp_body: "{\"key2\":2,\"key1\":1}"}
       end
     end
@@ -37,12 +37,12 @@ defmodule MiddlewareTest do
   end
 
   test "make use of headers" do
-    assert Client.get!|> get_resp_header == %{"Content-Type" => "application/json"}
-    assert Client.get!|> get_resp_header("Content-Type") == {"Content-Type", "application/json"}
+    assert Client.get!|> get_resp_headers() == %{"content-type" => "application/json"}
+    assert Client.get!|> get_resp_header("Content-Type") == "application/json"
   end
 
   test "make use of endeodejson" do
-    body = %{"key2" => 101, "key1" => 201} |> put_req_body |> Client.post! |> get_resp_body
+    body = new() |> put_req_body(%{"key2" => 101, "key1" => 201}) |> Client.post! |> get_resp_body
     assert true == Map.equal?(body, %{"key2" => 101, "key1" => 201})
   end
 

--- a/test/maxwell/middleware/middleware_test_helper.exs
+++ b/test/maxwell/middleware/middleware_test_helper.exs
@@ -1,11 +1,9 @@
 defmodule Maxwell.Middleware.TestHelper do
-
   def request(mid, env, opts) do
     mid.request(env, opts)
   end
   def response(mid, env, opts) do
     mid.response(env, opts)
   end
-
 end
 

--- a/test/maxwell/middleware/retry_test.exs
+++ b/test/maxwell/middleware/retry_test.exs
@@ -36,19 +36,19 @@ defmodule RetryTest do
   end
 
   test "pass on successful request" do
-    assert Conn.put_path("/ok") |> Client.get! |> Conn.get_resp_body() == "ok"
+    assert Conn.new("/ok") |> Client.get! |> Conn.get_resp_body() == "ok"
   end
 
   test "pass after retry" do
-    assert Conn.put_path("/maybe") |> Client.get! |> Conn.get_resp_body() == "maybe"
+    assert Conn.new("/maybe") |> Client.get! |> Conn.get_resp_body() == "maybe"
   end
 
   test "raise error if max_retries is exceeded" do
-    assert_raise Maxwell.Error, fn -> Conn.put_path("/nope") |> Client.get! end
+    assert_raise Maxwell.Error, fn -> Conn.new("/nope") |> Client.get! end
   end
 
   test "raise error if error other than econnrefused occurs" do
-    assert_raise Maxwell.Error, fn -> Conn.put_path("/boom") |> Client.get! end
+    assert_raise Maxwell.Error, fn -> Conn.new("/boom") |> Client.get! end
   end
 
 end


### PR DESCRIPTION
The following is a list of the changes made. To me, the ergonomics of this improved API are much nicer, as it's simpler to work with Conn, and the APIs tend to return what you'd expect if you think of Conn as any other data structure.

- Working with Conn APIs requires calling new/0 or new/1 first
  old APIs are deprecated
- new/1 parses the provided string with URI.parse/1 and sets the Conn
  struct fields accordingly (so you can pass full or partial url
  fragments and get what you would expect, including those containing
  query strings)
- All headers are normalized to lower-case on put/get, and internally
  headers are a simple key/value map instead of the previous key =>
  key/value map, which was unnecessary.
- Implemented get_req_headers/1, deprecated get_req_header/1
- Implemented put_req_headers/2, deprecated put_req_header/2
- get_req_header/2 returns String.t instead of {String.t, String.t}
- get_req_headers/1 returns %{String.t => String.t} instead of
  %{String.t => %{String.t => String.t}}
- Added a number of typespecs, and fixed invalid ones
- Some small style fixes, documentation updates
- Fixed a bug with the Header middleware which was not overriding
  headers in the connection if already set. This one may be up for
  discussion if what's really desired.
- I recall encountering one or two other places where the tests were asserting
the wrong thing, and so tests were passing even though the code was broken.

I'm opening this as a PR rather than just making the changes because it's a large changeset and you may not approve, but I think these are important changes to make and will make Maxwell much nicer to work with. I'll be using my fork in the meantime for that reason.