### PR TITLE
Improve the BaseUrl middleware

### DIFF
--- a/lib/maxwell/middleware/baseurl.ex
+++ b/lib/maxwell/middleware/baseurl.ex
@@ -2,41 +2,73 @@ defmodule Maxwell.Middleware.BaseUrl do
   @moduledoc  """
   Sets the base url for all requests in this module.
 
+  You may provide any valid URL, and it will be parsed into it's requisite parts and
+  assigned to the corresponding fields in the connection.
+
+  Providing a path in the URL will be treated as if it's a base path for all requests. If you subsequently
+  create a connection and use `put_path`, the base path set in this middleware will be prepended to the
+  path provided to `put_path`.
+
+  A base url is not valid if no host is set. You may omit the scheme, and it will default to `http://`.
+
   ## Examples
 
-        # Client.ex
-        use Maxwell.Builder ~(get)a
-        middleware Maxwell.Middleware.BaseUrl, "http{s}://example.com"
+      iex> opts = Maxwell.Middleware.BaseUrl.init("http://example.com")
+      ...> Maxwell.Middleware.BaseUrl.request(Maxwell.Conn.new("/foo"), opts)
+      %Maxwell.Conn{url: "http://example.com", path: "/foo"}
 
-        def get_home_page do
-          # request http{s}://example.com"
-          Client.get!
-        end
-
-        def request(path) do
-          # http{s}://example.com/\#\{path\}"
-          put_path(path) |> Client.get!
-        end
-
-        def request_other() do
-          # http{s}://other.com/other_path"
-          "http{s}://other.com/other_path" |> new() |> Client.get!
-          end
-
-        # Add query to url.
-        def request(url, query)when is_map(query) do
-          url |> new() |> put_query_string(query) |> Client.get!
-        end
-
+      iex> opts = Maxwell.Middleware.BaseUrl.init("http://example.com/api/?version=1")
+      ...> Maxwell.Middleware.BaseUrl.request(Maxwell.Conn.new("/users"), opts)
+      %Maxwell.Conn{url: "http://example.com", path: "/api/users", query_string: %{"version" => "1"}}
   """
   use Maxwell.Middleware
+  alias Maxwell.Conn
 
-  def request(%Maxwell.Conn{} = conn, base_url) do
-    if Regex.match?(~r/^https?:\/\//, conn.url) do
+  def init(base_url) do
+    conn = Conn.parse_url(base_url)
+    opts = %{url: conn.url, path: conn.path, query: conn.query_string}
+    case opts.url do
+      url when url in [nil, ""] ->
+        raise ArgumentError, "BaseUrl middleware expects a proper url containing a hostname, got #{base_url}"
+      _ ->
+        opts
+    end
+  end
+
+  def request(%Conn{} = conn, %{url: base_url, path: base_path, query: default_query}) do
+    conn
+    |> ensure_base_url(base_url)
+    |> ensure_base_path(base_path)
+    |> ensure_base_query(default_query)
+  end
+
+  # Ensures there is always a base url
+  defp ensure_base_url(%Conn{url: url} = conn, base_url) when url in [nil, ""] do
+    %{conn | url: base_url}
+  end
+  defp ensure_base_url(conn, _base_url), do: conn
+
+  # Ensures the base path is always present
+  defp ensure_base_path(%Conn{path: path} = conn, base_path) when path in [nil, ""] do
+    %{conn | path: base_path}
+  end
+  defp ensure_base_path(%Conn{path: path} = conn, base_path) do
+    if String.starts_with?(path, base_path) do
       conn
     else
-      %{conn | url: base_url}
+      %{conn | path: join_path(base_path, path)}
     end
+  end
+
+  # Ensures the default query strings are always present
+  defp ensure_base_query(%Conn{query_string: qs} = conn, default_query) do
+    %{conn | query_string: Map.merge(default_query, qs)}
+  end
+
+  defp join_path(a, b) do
+    a = String.trim_trailing(a, "/")
+    b = String.trim_leading(b, "/")
+    a <> "/" <> b
   end
 end
 

--- a/test/maxwell/middleware/base_url_test.exs
+++ b/test/maxwell/middleware/base_url_test.exs
@@ -1,16 +1,47 @@
 defmodule BaseUrlTest do
-  use ExUnit.Case
-  import Maxwell.Middleware.TestHelper
-  alias Maxwell.Conn
+  use ExUnit.Case 
+  import Maxwell.Middleware.TestHelper 
+  alias Maxwell.Conn 
 
-  test "Base Middleware.BaseUrl" do
-    conn = request(Maxwell.Middleware.BaseUrl, %Conn{url: "/path"}, "http://example.com")
+  test "simple base url" do
+    opts = Maxwell.Middleware.BaseUrl.init("http://example.com")
+    conn = request(Maxwell.Middleware.BaseUrl, %Conn{path: "/path"}, opts)
     assert conn.url == "http://example.com"
+    assert conn.path == "/path"
   end
 
-  test "Replace http Middleware.BaseUrl" do
-    conn = request(Maxwell.Middleware.BaseUrl, %Conn{url: "http://see_me.com/path"}, "http://can_not_seen.com/")
-    assert conn.url == "http://see_me.com/path"
+  test "base url and base path" do
+    opts = Maxwell.Middleware.BaseUrl.init("http://example.com/api/v1")
+    conn = request(Maxwell.Middleware.BaseUrl, %Conn{path: "/path"}, opts)
+    assert conn.url == "http://example.com"
+    assert conn.path == "/api/v1/path"
+  end
+
+  test "base url, base path, and default query" do
+    opts = Maxwell.Middleware.BaseUrl.init("http://example.com/api/v1?apiKey=foo")
+    conn = request(Maxwell.Middleware.BaseUrl, %Conn{path: "/path"}, opts)
+    assert conn.url == "http://example.com"
+    assert conn.path == "/api/v1/path"
+    assert conn.query_string == %{"apiKey" => "foo"}
+  end
+
+  test "default query is merged" do
+    opts = Maxwell.Middleware.BaseUrl.init("http://example.com/api/v1?apiKey=foo&user=me")
+    conn = %Conn{path: "/path", query_string: %{"apiKey" => "bar", "other" => "thing"}}
+    conn = request(Maxwell.Middleware.BaseUrl, conn, opts)
+    assert conn.url == "http://example.com"
+    assert conn.path == "/api/v1/path"
+    assert conn.query_string == %{"apiKey" => "bar", "other" => "thing", "user" => "me"}
+  end
+
+  test "base url can be overriden if set on connection" do
+    opts = Maxwell.Middleware.BaseUrl.init("http://notseen.com")
+    conn = request(Maxwell.Middleware.BaseUrl, %Conn{url: "http://seen/path"}, opts)
+    assert conn.url == "http://seen/path"
+  end
+
+  test "invalid base url will raise an ArgumentError" do
+    assert_raise ArgumentError, fn -> Maxwell.Middleware.BaseUrl.init("/foo") end
   end
 end
 


### PR DESCRIPTION
The old BaseUrl middleware was very naive, it simply set
the url field of the connection to whatever was provided.
This new version actually parses the URL and sets the different
Conn fields accordingly. It also validates that the base url actually
contains a host, so that a valid request can be made.