### PR TITLE
make url<>path more elastic

### DIFF
--- a/lib/maxwell.ex
+++ b/lib/maxwell.ex
@@ -7,8 +7,8 @@ defmodule Maxwell do
   ### Basic Usage
 
       ## Returns Origin IP, for example %{"origin" => "127.0.0.1"}
-      Maxwell.Conn.new("http://httpbin.org")
-      |> Maxwell.put_path("/ip")
+      "http://httpbin.org/ip"
+      |> Maxwell.Conn.new()
       |> Maxwell.get!()
       |> Maxwell.Conn.get_resp_body()
       |> Poison.decode!()
@@ -28,16 +28,16 @@ defmodule Maxwell do
 
            ## Returns origin IP, for example "127.0.0.1"
            def ip() do
-             new()
-             |> put_path("/ip")
+             "/ip"
+             |> new()
              |> get!()
              |> get_resp_body("origin")
            end
 
            ## Generates n random bytes of binary data, accepts optional seed integer parameter
            def get_random_bytes(size) do
-             new()
-             |> put_path("/bytes/\#\{size\}")
+             "/bytes/\#\{size\}"
+             |> new()
              |> get!()
              |> get_resp_body(&to_string/1)
            end

--- a/lib/maxwell.ex
+++ b/lib/maxwell.ex
@@ -2,16 +2,16 @@ defmodule Maxwell do
   @moduledoc  """
   The maxwell specification.
 
-  There are two kind of usages: Basic Usage and Advanced Middleware Usage.
+  There are two kind of usages: basic usage and advanced middleware usage.
 
   ### Basic Usage
 
       ## Returns Origin IP, for example %{"origin" => "127.0.0.1"}
-      Maxwell.Conn.new
-      |> Maxwell.Conn.put_url("http://httpbin.org/ip")
-      |> Maxwell.get!
-      |> Maxwell.Conn.get_resp_body
-      |> Poison.decode!
+      Maxwell.Conn.new("http://httpbin.org")
+      |> Maxwell.put_path("/ip")
+      |> Maxwell.get!()
+      |> Maxwell.Conn.get_resp_body()
+      |> Poison.decode!()
 
   Find all `get_*&put_*` helper functions by `h Maxwell.Conn.xxx`
 
@@ -22,23 +22,23 @@ defmodule Maxwell do
            adapter Maxwell.Adapter.Ibrowse
 
            middleware Maxwell.Middleware.BaseUrl,   "http://httpbin.org"
-           middleware Maxwell.Middleware.Opts,      [connect_timeout: 1000]
-           middleware Maxwell.Middleware.Headers,   %{'User-Agent' => "zhongwencool"}
+           middleware Maxwell.Middleware.Opts,      [connect_timeout: 5000]
+           middleware Maxwell.Middleware.Headers,   %{"User-Agent" => "zhongwencool"}
            middleware Maxwell.Middleware.Json
 
            ## Returns origin IP, for example "127.0.0.1"
-           def ip do
+           def ip() do
              new()
-             |> put_path("ip")
+             |> put_path("/ip")
              |> get!()
              |> get_resp_body("origin")
            end
 
            ## Generates n random bytes of binary data, accepts optional seed integer parameter
            def get_random_bytes(size) do
-             "/bytes/\#\{size\}"
-             |> put_path
-             |> get!
+             new()
+             |> put_path("/bytes/\#\{size\}")
+             |> get!()
              |> get_resp_body(&to_string/1)
            end
         end

--- a/lib/maxwell/adapter/util.ex
+++ b/lib/maxwell/adapter/util.ex
@@ -23,6 +23,7 @@ defmodule Maxwell.Adapter.Util do
 
   """
   def url_serialize(url, path, query_string, type \\ :string) do
+    IO.inspect {:xxxxxxx, url, path}
     url = url |> append_query_string(path, query_string)
     case type do
       :string -> url
@@ -136,23 +137,10 @@ defmodule Maxwell.Adapter.Util do
   end
   defp multipart_body(:end), do: :eof
 
-  defp append_query_string(url, path, query)when query == %{}, do: url_joint_path(url, path)
+  defp append_query_string(url, path, query)when query == %{}, do: Path.join(url, path)
   defp append_query_string(url, path, query) do
     query_string = URI.encode_query(query)
-    url_path = url_joint_path(url ,path)
-    url_path <> "?" <> query_string
-  end
-
-  defp url_joint_path(url, path) do
-    case {String.ends_with?(url, "/"), String.starts_with?(path, "/")} do
-      {false, false} ->
-        url <> "/" <> path
-      {true, true}   ->
-        "/" <> new_path = path
-        url <> new_path
-      _ ->
-        url <> path
-    end
+    Path.join(url, path) <> "?" <> query_string
   end
 
 end

--- a/lib/maxwell/adapter/util.ex
+++ b/lib/maxwell/adapter/util.ex
@@ -136,17 +136,24 @@ defmodule Maxwell.Adapter.Util do
   end
   defp multipart_body(:end), do: :eof
 
-  defp append_query_string(url, path, query)when query == %{}, do: url <> path
+  defp append_query_string(url, path, query)when query == %{}, do: url_joint_path(url, path)
   defp append_query_string(url, path, query) do
     query_string = URI.encode_query(query)
+    url_path = url_joint_path(url ,path)
+    url_path <> "?" <> query_string
+  end
+
+  defp url_joint_path(url, path) do
     case {String.ends_with?(url, "/"), String.starts_with?(path, "/")} do
       {false, false} ->
-        url <> "/" <> path <> "?" <> query_string
+        url <> "/" <> path
       {true, true}   ->
         "/" <> new_path = path
-        url <> new_path <> "?" <> query_string
+        url <> new_path
       _ ->
-        url <> path <> "?" <> query_string
+        url <> path
     end
   end
+
 end
+

--- a/lib/maxwell/adapter/util.ex
+++ b/lib/maxwell/adapter/util.ex
@@ -139,6 +139,14 @@ defmodule Maxwell.Adapter.Util do
   defp append_query_string(url, path, query)when query == %{}, do: url <> path
   defp append_query_string(url, path, query) do
     query_string = URI.encode_query(query)
-    url <> path <> "?" <> query_string
+    case {String.ends_with?(url, "/"), String.starts_with?(path, "/")} do
+      {false, false} ->
+        url <> "/" <> path <> "?" <> query_string
+      {true, true}   ->
+        "/" <> new_path = path
+        url <> new_path <> "?" <> query_string
+      _ ->
+        url <> path <> "?" <> query_string
+    end
   end
 end

--- a/lib/maxwell/adapter/util.ex
+++ b/lib/maxwell/adapter/util.ex
@@ -23,7 +23,6 @@ defmodule Maxwell.Adapter.Util do
 
   """
   def url_serialize(url, path, query_string, type \\ :string) do
-    IO.inspect {:xxxxxxx, url, path}
     url = url |> append_query_string(path, query_string)
     case type do
       :string -> url

--- a/test/maxwell/adapter/adapter_test.exs
+++ b/test/maxwell/adapter/adapter_test.exs
@@ -87,7 +87,7 @@ defmodule MaxwellAdapterTest do
 
   test "path + query" do
     conn = new("http://example.com/foo?a=1&b=foo")
-      |> Client.get!
+    |> Client.get!
     assert conn.url == "http://example.com"
     assert conn.path == "/foo"
     assert conn.query_string == %{"a" => "1", "b" => "foo"}

--- a/test/maxwell/adapter/adapter_test_helper.exs
+++ b/test/maxwell/adapter/adapter_test_helper.exs
@@ -26,45 +26,52 @@ defmodule Maxwell.Adapter.TestHelper do
         end
 
         def user_agent_test(user_agent) do
-          new("/user-agent")
+          "/user-agent"
+          |> new()
           |> put_req_header("user-agent", user_agent)
           |> get!
           |> get_resp_body("user-agent")
         end
 
         def put_json_test(json) do
-          new("/put")
+          "/put"
+          |> new()
           |> put_req_body(json)
           |> put!
           |> get_resp_body("data")
         end
 
         def delete_test() do
-          new("/delete")
+          "delete"
+          |> new()
           |> delete!
           |> get_resp_body("data")
         end
 
         def multipart_test() do
-          new("/post")
+          "/post"
+          |> new()
           |> put_req_body({:multipart, [{:file, "test/maxwell/multipart_test_file.sh"}]})
           |> post!
         end
         def multipart_with_extra_header_test() do
-          new("/post")
+          "/post"
+          |> new()
           |> put_req_body({:multipart, [{:file, "test/maxwell/multipart_test_file.sh", [{"Content-Type", "image/jpeg"}]}]})
           |> post!
         end
 
         def file_test(filepath) do
-          new("/post")
+          "/post"
+          |> new()
           |> put_req_header("transfer-encoding", "chunked")
           |> put_req_body({:file, filepath})
           |> post!
         end
 
         def file_test(filepath, content_type) do
-          new("/post")
+          "/post"
+          |> new()
           |> put_req_header("transfer-encoding", "Chunked")
           |> put_req_body({:file, filepath})
           |> put_req_header("content-type", content_type)
@@ -72,14 +79,16 @@ defmodule Maxwell.Adapter.TestHelper do
         end
 
         def file_without_transfer_encoding_test(filepath, content_type) do
-          new("/post")
+          "/post"
+          |> new()
           |> put_req_body({:file, filepath})
           |> put_req_header("content-type", content_type)
           |> post!
         end
 
         def stream_test() do
-          new("/post")
+          "/post"
+          |> new()
           |> put_req_header("content-type", "application/vnd.lotus-1-2-3")
           |> put_req_header("content-length", 6)
           |> put_req_body(Stream.map(["1", "2", "3"], fn(x) -> List.duplicate(x, 2) end))

--- a/test/maxwell/adapter/adapter_test_helper.exs
+++ b/test/maxwell/adapter/adapter_test_helper.exs
@@ -14,11 +14,12 @@ defmodule Maxwell.Adapter.TestHelper do
         middleware Maxwell.Middleware.Json
 
         def get_ip_test() do
-          get!(new("/ip"))
+          "/ip" |> new() |> get!()
         end
 
         def encode_decode_json_test(body) do
-          new("/post")
+          "post"
+          |> new()
           |> put_req_body(body)
           |> post!
           |> get_resp_body("json")

--- a/test/maxwell/adapter/adapter_test_helper.exs
+++ b/test/maxwell/adapter/adapter_test_helper.exs
@@ -18,7 +18,7 @@ defmodule Maxwell.Adapter.TestHelper do
         end
 
         def encode_decode_json_test(body) do
-          "post"
+          "/post"
           |> new()
           |> put_req_body(body)
           |> post!

--- a/test/maxwell/adapter/hackney_test.exs
+++ b/test/maxwell/adapter/hackney_test.exs
@@ -17,10 +17,11 @@ defmodule Maxwell.HackneyMockTest do
     middleware Maxwell.Middleware.Json
 
     def get_ip_test do
-      get!(new("/ip"))
+      new() |> put_path("ip") |> get!()
     end
     def encode_decode_json_test(body) do
-      new("/post")
+      new()
+      |> put_path("/post")
       |> put_req_body(body)
       |> post!
       |> get_resp_body("json")

--- a/test/maxwell/adapter/hackney_test.exs
+++ b/test/maxwell/adapter/hackney_test.exs
@@ -17,61 +17,69 @@ defmodule Maxwell.HackneyMockTest do
     middleware Maxwell.Middleware.Json
 
     def get_ip_test do
-      new() |> put_path("ip") |> get!()
+      "ip" |> new() |> get!()
     end
     def encode_decode_json_test(body) do
-      new()
-      |> put_path("/post")
+      "/post"
+      |> new()
       |> put_req_body(body)
       |> post!
       |> get_resp_body("json")
     end
 
     def user_agent_test(user_agent) do
-      new("/user-agent")
+      "/user-agent"
+      |> new()
       |> put_req_header("user-agent", user_agent)
       |> get!
       |> get_resp_body("user-agent")
     end
 
     def put_json_test(json) do
-      new("/put")
+      "/put"
+      |> new()
       |> put_req_body(json)
       |> put!
       |> get_resp_body("data")
     end
 
     def delete_test() do
-      new("/delete")
+      "/delete"
+      |> new()
       |> delete!
       |> get_resp_body("data")
     end
 
     def timeout_test() do
-      new("/delay/5")
+      "/delay/5"
+      |> new()
       |> put_option(:recv_timeout, 1000)
       |> Client.get
     end
 
     def multipart_test() do
-      new("/post")
+      "/post"
+      |> new()
       |> put_req_body({:multipart, [{:file, "test/maxwell/multipart_test_file.sh"}]})
       |> Client.post!
     end
     def multipart_with_extra_header_test() do
-      new("/post")
+      "/post"
+      |> new()
       |> put_req_body({:multipart, [{:file, "test/maxwell/multipart_test_file.sh", [{"Content-Type", "image/jpeg"}]}]})
       |> Client.post!
     end
 
     def file_test() do
-      new("/post")
+      "/post"
+      |> new()
       |> put_req_body({:file, "test/maxwell/multipart_test_file.sh"})
       |> Client.post!
     end
 
     def stream_test() do
-      new("/post")
+      "/post"
+      |> new()
       |> put_req_body(Stream.map(["1", "2", "3"], fn(x) -> List.duplicate(x, 2) end))
       |> Client.post!
     end

--- a/test/maxwell/adapter/ibrowse_test.exs
+++ b/test/maxwell/adapter/ibrowse_test.exs
@@ -16,11 +16,12 @@ defmodule Maxwell.IbrowseMockTest do
     middleware Maxwell.Middleware.Json
 
     def get_ip_test() do
-      "/ip" |> new() |> Client.get!
+      new() |> put_path("/ip") |> Client.get!
     end
 
     def encode_decode_json_test(body) do
-      new("/post")
+      new()
+      |> put_path("post")
       |> put_req_body(body)
       |> post!
       |> get_resp_body("json")

--- a/test/maxwell/adapter/ibrowse_test.exs
+++ b/test/maxwell/adapter/ibrowse_test.exs
@@ -16,75 +16,85 @@ defmodule Maxwell.IbrowseMockTest do
     middleware Maxwell.Middleware.Json
 
     def get_ip_test() do
-      new() |> put_path("/ip") |> Client.get!
+      "/ip" |> new() |> Client.get!
     end
 
     def encode_decode_json_test(body) do
-      new()
-      |> put_path("post")
+      "post"
+      |> new()
       |> put_req_body(body)
       |> post!
       |> get_resp_body("json")
     end
 
     def user_agent_test(user_agent) do
-      new("/user-agent")
+      "/user-agent"
+      |> new()
       |> put_req_header("user-agent", user_agent)
       |> get!
       |> get_resp_body("user-agent")
     end
 
     def put_json_test(json) do
-      new("/put")
+      "/put"
+      |> new()
       |> put_req_body(json)
       |> put!
       |> get_resp_body("data")
     end
 
     def delete_test() do
-      new("/delete")
+      "/delete"
+      |> new()
       |> delete!
       |> get_resp_body("data")
     end
 
     def normalized_error_test() do
-      new("http://broken.local")
+      "http://broken.local"
+      |> new()
       |> get
     end
 
     def timeout_test() do
-      new("/delay/5")
+      "/delay/5"
+      |> new()
       |> put_query_string("foo", "bar")
       |> put_option(:inactivity_timeout, 1000)
       |> Client.get
     end
 
     def multipart_test() do
-      new("/post")
+      "/post"
+      |> new()
       |> put_req_body({:multipart, [{:file, "test/maxwell/multipart_test_file.sh"}]})
       |> Client.post!
     end
     def multipart_with_extra_header_test() do
-      new("/post")
+      "/post"
+      |> new()
       |> put_req_body({:multipart, [{:file, "test/maxwell/multipart_test_file.sh", [{"Content-Type", "image/jpeg"}]}]})
       |> Client.post!
     end
 
     def file_test(filepath) do
-      new("/post")
+      "/post"
+      |> new()
       |> put_req_body({:file, filepath})
       |> Client.post!
     end
 
     def file_test(filepath, content_type) do
-      new("/post")
+      "/post"
+      |> new()
       |> put_req_body({:file, filepath})
       |> put_req_header("content-type", content_type)
       |> Client.post!
     end
 
     def stream_test() do
-      new("/post")
+      "/post"
+      |> new()
       |> put_req_header("content-type", "application/vnd.lotus-1-2-3")
       |> put_req_header("content-length", 6)
       |> put_req_body(Stream.map(["1", "2", "3"], fn(x) -> List.duplicate(x, 2) end))

--- a/test/maxwell/adapter/ibrowse_test.exs
+++ b/test/maxwell/adapter/ibrowse_test.exs
@@ -11,12 +11,12 @@ defmodule Maxwell.IbrowseMockTest do
     use Maxwell.Builder
     adapter Maxwell.Adapter.Ibrowse
 
-    middleware Maxwell.Middleware.BaseUrl, "http://httpbin.org"
+    middleware Maxwell.Middleware.BaseUrl, "http://httpbin.org/"
     middleware Maxwell.Middleware.Opts, [connect_timeout: 5000]
     middleware Maxwell.Middleware.Json
 
     def get_ip_test() do
-      new("/ip") |> Client.get!
+      "/ip" |> new() |> Client.get!
     end
 
     def encode_decode_json_test(body) do


### PR DESCRIPTION
Deal with `/` between url and path more elastic.
```elixir
url = "http://example.com/"
path = "login"
url_path = "http://example.com/login"
```

```elixir
url = "http://example.com"
path = "login"
url_path = "http://example.com/login"
```
```elixir
url = "http://example.com/"
path = "/login"
url_path = "http://example.com/login"
```