### PR TITLE
Applied dialyzer fixes

### DIFF
--- a/lib/maxwell/adapter/adapter.ex
+++ b/lib/maxwell/adapter/adapter.ex
@@ -30,9 +30,10 @@ defmodule Maxwell.Adapter do
         case res do
           %Conn{} -> res
           {:error, _reason, _conn} -> res
-          other ->
-            raise "invalid return from #{unquote(__CALLER__.module)}" <>
-                  " expected Maxwell.Conn.t or {:error, reason}, but got: #{inspect other}"
+# according to dialyzer this can never match since previous clauses completely covered the type {'error',_,#{'__struct__':='Elixir.Maxwell.Conn', 'method':=_, 'opts':=_, 'path':=_, 'query_string':=_, 'req_body':=_, 'req_headers':=_, 'state':='error', 'url':=_, _=>_}} | #{'__struct__':='Elixir.Maxwell.Conn', 'method':=_, 'opts':=_, 'path':=_, 'query_string':=_, 'req_body':='nil', 'req_headers':=_, 'resp_body':=binary(), 'resp_headers':=_, 'state':='sent', 'status':=_, 'url':=_, _=>_}
+#          other ->
+#            raise "invalid return from #{unquote(__CALLER__.module)}" <>
+#                  " expected Maxwell.Conn.t or {:error, reason}, but got: #{inspect other}"
         end
       end
 

--- a/lib/maxwell/adapter/adapter.ex
+++ b/lib/maxwell/adapter/adapter.ex
@@ -30,10 +30,10 @@ defmodule Maxwell.Adapter do
         case res do
           %Conn{} -> res
           {:error, _reason, _conn} -> res
-# according to dialyzer this can never match since previous clauses completely covered the type {'error',_,#{'__struct__':='Elixir.Maxwell.Conn', 'method':=_, 'opts':=_, 'path':=_, 'query_string':=_, 'req_body':=_, 'req_headers':=_, 'state':='error', 'url':=_, _=>_}} | #{'__struct__':='Elixir.Maxwell.Conn', 'method':=_, 'opts':=_, 'path':=_, 'query_string':=_, 'req_body':='nil', 'req_headers':=_, 'resp_body':=binary(), 'resp_headers':=_, 'state':='sent', 'status':=_, 'url':=_, _=>_}
-#          other ->
-#            raise "invalid return from #{unquote(__CALLER__.module)}" <>
-#                  " expected Maxwell.Conn.t or {:error, reason}, but got: #{inspect other}"
+
+          other ->
+            raise "invalid return from #{unquote(__CALLER__.module)}" <>
+                  " expected Maxwell.Conn.t or {:error, reason}, but got: #{inspect other}"
         end
       end
 

--- a/lib/maxwell/adapter/adapter.ex
+++ b/lib/maxwell/adapter/adapter.ex
@@ -30,7 +30,6 @@ defmodule Maxwell.Adapter do
         case res do
           %Conn{} -> res
           {:error, _reason, _conn} -> res
-
           other ->
             raise "invalid return from #{unquote(__CALLER__.module)}" <>
                   " expected Maxwell.Conn.t or {:error, reason}, but got: #{inspect other}"

--- a/lib/maxwell/conn.ex
+++ b/lib/maxwell/conn.ex
@@ -39,17 +39,17 @@ defmodule Maxwell.Conn do
   @type file_body_t :: {:file, Path.t}
   @type t :: %__MODULE__{
     state: :unsent | :sending | :sent | :error,
-    method: Atom.t,
+    method: atom,
     url: String.t,
     path: String.t,
-    query_string: Map.t,
+    query_string: map,
     opts: Keyword.t,
     req_headers: %{binary => binary},
-    req_body: iodata | Map.t | Maxwell.Multipart.t | file_body_t | Stream.t,
+    req_body: iodata | map | Maxwell.Multipart.t | file_body_t | Enumerable.t,
     status: non_neg_integer | nil,
     resp_headers: %{binary => binary},
-    resp_body: iodata | Map.t,
-    private: Map.t
+    resp_body: iodata | map,
+    private: map
   }
 
   defstruct state: :unsent,
@@ -324,7 +324,7 @@ defmodule Maxwell.Conn do
       iex> put_req_body(new(), "new body")
       %Maxwell.Conn{req_body: "new_body"}
   """
-  @spec put_req_body(t, Stream.t | binary()) :: t | no_return
+  @spec put_req_body(t, Enumerable.t | binary()) :: t | no_return
   def put_req_body(%Conn{state: :unsent} = conn, req_body) do
     %{conn | req_body: req_body}
   end
@@ -429,7 +429,7 @@ defmodule Maxwell.Conn do
       |> put_private(:user_id, "zhongwencool")
       %Maxwell.Conn{private: %{user_id: "zhongwencool"}}
   """
-  @spec put_private(t, Atom.t, term()) :: t
+  @spec put_private(t, atom, term()) :: t
   def put_private(%Conn{private: private} = conn, key, value) do
     new_private = Map.put(private, key, value)
     %{conn | private: new_private}
@@ -444,7 +444,7 @@ defmodule Maxwell.Conn do
       |> get_private(:user_id)
       "zhongwencool"
   """
-  @spec get_private(t, Atom.t) :: term()
+  @spec get_private(t, atom) :: term()
   def get_private(%Conn{private: private}, key) do
     Map.get(private, key)
   end

--- a/lib/maxwell/error.ex
+++ b/lib/maxwell/error.ex
@@ -8,6 +8,7 @@ defmodule Maxwell.Error do
   """
   defexception [:url, :status, :method, :reason, :message, :conn]
 
+  @spec exception({module, atom | binary, Maxwell.Conn.t}) :: Exception.t
   def exception({module, reason, conn}) do
     %Maxwell.Conn{url: url, status: status, method: method, path: path} = conn
     message = """


### PR DESCRIPTION
Hi there,

I had some Dialyzer errors in my project coming from Maxwell, so I thought to give it a look.

- I  changed the type specs of conn.ex for Atom.t, Map.t, and Stream.t, which do not exist, to their original types.
- Added type spec for error.ex.
- Commented out  unreachable code in adapter.ex, which according to Dialyzer will never be triggered.
I've been tracing the calls and I can confirm this is indeed not possible since all paths that lead to this are indeed already covered. Please double check this as well, and then remove :)

There is just one error left which is :
```elixir
lib/maxwell.ex:1: The pattern _@2 = {'error', _} can never match the type {'error',_,#{'__struct__':='Elixir.Maxwell.Conn', 'method':=atom(), 'opts':=[{_,_}], 'path':=binary(), 'private':=map(), 'query_string':=map(), 'req_body':=_, 'req_headers':=#{binary()=>binary()}, 'resp_body':=binary() | maybe_improper_list(binary() | maybe_improper_list(any(),binary() | []) | byte(),binary() | []) | map(), 'resp_headers':=#{binary()=>binary()}, 'state':='error', 'status':='nil' | non_neg_integer(), 'url':=binary()}} | #{'__struct__':='Elixir.Maxwell.Conn', 'method':=atom(), 'opts':=[{atom(),_}], 'path':=binary(), 'private':=map(), 'query_string':=map(), 'req_body':='nil', 'req_headers':=#{binary()=>binary()}, 'resp_body':=binary() | maybe_improper_list(binary() | maybe_improper_list(any(),binary() | []) | byte(),binary() | []) | map(), 'resp_headers':=#{binary()=>binary()}, 'state':='sent', 'status':=non_neg_integer(), 'url':=binary()}

```

This is coming from the macro in builder.ex. As it is a macro it's really hard for me to track down the origins of the error. Basically what it is saying is that in the code an {:error, :message} is being thrown, while that should be {:error, :message, %Maxwell.Conn{}} , I could not find exactly where this happens so maybe you can have a look at that ?

Thanks for your time :)
Gerard