### PR TITLE
Multipart.add_file_content_with_name (issue #69)

### DIFF
--- a/lib/maxwell/adapter/hackney.ex
+++ b/lib/maxwell/adapter/hackney.ex
@@ -15,7 +15,11 @@ if Code.ensure_loaded?(:hackney) do
       format_response(result, conn)
     end
 
-    def send_multipart(conn), do: send_direct(conn)
+    def send_multipart(conn) do
+      %Conn{req_body: {:multipart, multiparts}} = conn
+      {req_headers, req_body} = Util.multipart_encode(conn, multiparts)
+      send_direct(%Conn{conn | req_headers: req_headers, req_body: req_body})
+    end
 
     def send_file(conn), do: send_direct(conn)
 


### PR DESCRIPTION
This PR extend Multipart functions with:

* `Multipart.add_file_content`
* `Multipart.add_file_content_with_name`

Those are a variation on `Multipart.add_file` and `* Multipart.add_file_with_name`. They accept the file_content binary in place of file_path.

**Note**
Multipart was strictly based on hackney multipart implementation and so the `{:multipart, multiparts}` request body form was fully compatible with `:hackney.request`.

With this extension we diverge from hackney breaking the request body compatibility.
This is the reason why I changed `Maxwell.Adapter.Hackney.send_multipart` callback to use a `Util.multipart_encode`.

Another option is to open a PR to hackney in the same direct of this one.

In my opinion, given that only hackney natively support multipart body, it's better to use for all the adapter the Maxwell multipart encoder. It is consistent among all adapter library and easier to maintain.

If you agree with me, a further improvement could be refactoring out `send_multipart` callback from all the adapters and call `Util.multipart_encode` in adapter.ex `call` before passing down to `send_direct` (as I did in this PR for hackney). Let me know.