### PR TITLE
Refactor send_multipart callback

### DIFF
--- a/lib/maxwell/adapter/hackney.ex
+++ b/lib/maxwell/adapter/hackney.ex
@@ -15,12 +15,6 @@ if Code.ensure_loaded?(:hackney) do
       format_response(result, conn)
     end
 
-    def send_multipart(conn) do
-      %Conn{req_body: {:multipart, multiparts}} = conn
-      {req_headers, req_body} = Util.multipart_encode(conn, multiparts)
-      send_direct(%Conn{conn | req_headers: req_headers, req_body: req_body})
-    end
-
     def send_file(conn), do: send_direct(conn)
 
     def send_stream(conn) do

--- a/lib/maxwell/adapter/httpc.ex
+++ b/lib/maxwell/adapter/httpc.ex
@@ -17,17 +17,6 @@ defmodule Maxwell.Adapter.Httpc do
     format_response(result, conn)
   end
 
-  def send_multipart(conn) do
-    %Conn{url: url,query_string: query_string, path: path,
-          method: method, opts: opts, req_body: {:multipart, multiparts}} = conn
-    url = Util.url_serialize(url, path, query_string, :char_list)
-    {req_headers, req_body} = Util.multipart_encode(conn, multiparts)
-    {content_type, req_headers} = header_serialize(req_headers)
-    {http_opts, options} = opts_serialize(opts)
-    result = request(method, url, req_headers, content_type, req_body, http_opts, options)
-    format_response(result, conn)
-  end
-
   def send_file(conn) do
     %Conn{url: url, query_string: query_string, path: path,
           method: method, opts: opts, req_body: {:file, filepath}} = conn

--- a/lib/maxwell/adapter/ibrowse.ex
+++ b/lib/maxwell/adapter/ibrowse.ex
@@ -15,16 +15,6 @@ if Code.ensure_loaded?(:ibrowse) do
       format_response(result, conn)
     end
 
-    def send_multipart(conn) do
-      %Conn{url: url,query_string: query_string, path: path,
-            method: method, opts: opts, req_body: {:multipart, multiparts}} = conn
-      url = Util.url_serialize(url, path, query_string, :char_list)
-      {req_headers, req_body} = Util.multipart_encode(conn, multiparts)
-      req_headers = Util.header_serialize(req_headers)
-      result = :ibrowse.send_req(url, req_headers, method, req_body, opts)
-      format_response(result, conn)
-    end
-
     def send_file(conn) do
       %Conn{url: url, query_string: query_string, path: path,
             method: method, opts: opts, req_body: {:file, filepath}} = conn

--- a/test/maxwell/adapter/adapter_test_helper.exs
+++ b/test/maxwell/adapter/adapter_test_helper.exs
@@ -54,6 +54,12 @@ defmodule Maxwell.Adapter.TestHelper do
           |> put_req_body({:multipart, [{:file, "test/maxwell/multipart_test_file.sh"}]})
           |> post!
         end
+        def multipart_file_content_test() do
+          "/post"
+          |> new()
+          |> put_req_body({:multipart, [{:file_content, "xxx", "test.txt"}]})
+          |> post!
+        end
         def multipart_with_extra_header_test() do
           "/post"
           |> new()
@@ -117,12 +123,17 @@ defmodule Maxwell.Adapter.TestHelper do
         assert result == %{"josnkey1" => "jsonvalue1", "josnkey2" => "jsonvalue2"}
       end
 
-      test "mutilpart body file" do
+      test "multipart body file" do
         conn = unquote(client).multipart_test
         assert get_resp_body(conn, "files") == %{"file" => "#!/usr/bin/env bash\necho \"test multipart file\"\n"}
       end
 
-      test "mutilpart body file extra headers" do
+      test "multipart body file_content" do
+        conn = unquote(client).multipart_file_content_test
+        assert get_resp_body(conn, "files") == %{"file" => "xxx"}
+      end
+
+      test "multipart body file extra headers" do
         conn = unquote(client).multipart_with_extra_header_test
         assert get_resp_body(conn, "files") == %{"file" => "#!/usr/bin/env bash\necho \"test multipart file\"\n"}
       end

--- a/test/maxwell/adapter/hackney_test.exs
+++ b/test/maxwell/adapter/hackney_test.exs
@@ -57,19 +57,6 @@ defmodule Maxwell.HackneyMockTest do
       |> Client.get
     end
 
-    def multipart_test() do
-      "/post"
-      |> new()
-      |> put_req_body({:multipart, [{:file, "test/maxwell/multipart_test_file.sh"}]})
-      |> Client.post!
-    end
-    def multipart_with_extra_header_test() do
-      "/post"
-      |> new()
-      |> put_req_body({:multipart, [{:file, "test/maxwell/multipart_test_file.sh", [{"Content-Type", "image/jpeg"}]}]})
-      |> Client.post!
-    end
-
     def file_test() do
       "/post"
       |> new()
@@ -126,35 +113,6 @@ defmodule Maxwell.HackneyMockTest do
     res = %{"josnkey1" => "jsonvalue1", "josnkey2" => "jsonvalue2"} |> Client.encode_decode_json_test
     assert res == %{"josnkey1" => "jsonvalue1", "josnkey2" => "jsonvalue2"}
 
-  end
-
-  test_with_mock "mutilpart body file", :hackney,
-    [request: fn(_,_,_,_,_) ->
-      {:ok, 200,
-       [{"Server", "nginx"}, {"Date", "Sun, 18 Dec 2016 03:42:07 GMT"},
-        {"Content-Type", "application/json"}, {"Content-Length", "428"},
-        {"Connection", "keep-alive"}, {"Access-Control-Allow-Origin", "*"},
-        {"Access-Control-Allow-Credentials", "true"}], make_ref()} end,
-     body: fn _ -> {:ok,
-                     "{\n  \"args\": {}, \n  \"data\": \"\", \n  \"files\": {\n    \"file\": \"#!/usr/bin/env bash\\necho \\\"test multipart file\\\"\\n\"\n  }, \n  \"form\": {}, \n  \"headers\": {\n    \"Content-Length\": \"279\", \n    \"Content-Type\": \"multipart/form-data; boundary=---------------------------tvvbujkbhrbruqcy\", \n    \"Host\": \"httpbin.org\", \n    \"User-Agent\": \"hackney/1.6.3\"\n  }, \n  \"json\": null, \n  \"origin\": \"183.240.20.213\", \n  \"url\": \"http://httpbin.org/post\"\n}\n"}
-     end ] do
-    conn = Client.multipart_test
-    assert get_resp_body(conn, "files") == %{"file" => "#!/usr/bin/env bash\necho \"test multipart file\"\n"}
-  end
-
-  test_with_mock "mutilpart body file extra headers", :hackney,
-    [request: fn(_,_,_,_,_) ->
-      {:ok, 200,
-       [{"Server", "nginx"}, {"Date", "Sun, 18 Dec 2016 03:45:10 GMT"},
-        {"Content-Type", "application/json"}, {"Content-Length", "428"},
-        {"Connection", "keep-alive"}, {"Access-Control-Allow-Origin", "*"},
-        {"Access-Control-Allow-Credentials", "true"}], make_ref()}
-    end, body: fn _ ->
-      {:ok,
-       "{\n  \"args\": {}, \n  \"data\": \"\", \n  \"files\": {\n    \"file\": \"#!/usr/bin/env bash\\necho \\\"test multipart file\\\"\\n\"\n  }, \n  \"form\": {}, \n  \"headers\": {\n    \"Content-Length\": \"273\", \n    \"Content-Type\": \"multipart/form-data; boundary=---------------------------dlhrimiytrrvmxqk\", \n    \"Host\": \"httpbin.org\", \n    \"User-Agent\": \"hackney/1.6.3\"\n  }, \n  \"json\": null, \n  \"origin\": \"183.240.20.213\", \n  \"url\": \"http://httpbin.org/post\"\n}\n"}
-    end ] do
-    conn = Client.multipart_with_extra_header_test
-    assert get_resp_body(conn, "files") == %{"file" => "#!/usr/bin/env bash\necho \"test multipart file\"\n"}
   end
 
   test_with_mock "send file", :hackney,

--- a/test/maxwell/adapter/httpc_test.exs
+++ b/test/maxwell/adapter/httpc_test.exs
@@ -56,17 +56,6 @@ defmodule Maxwell.HttpcMockTest do
       |> Client.get
     end
 
-    def multipart_test() do
-      new("/post")
-      |> put_req_body({:multipart, [{:file, "test/maxwell/multipart_test_file.sh"}]})
-      |> Client.post!
-    end
-    def multipart_with_extra_header_test() do
-      new("/post")
-      |> put_req_body({:multipart, [{:file, "test/maxwell/multipart_test_file.sh", [{"Content-Type", "image/jpeg"}]}]})
-      |> Client.post!
-    end
-
     def file_test(filepath) do
       new("/post")
       |> put_req_body({:file, filepath})
@@ -126,34 +115,6 @@ defmodule Maxwell.HttpcMockTest do
     end] do
     result = %{"josnkey1" => "jsonvalue1", "josnkey2" => "jsonvalue2"} |> Client.encode_decode_json_test
     assert result == %{"josnkey1" => "jsonvalue1", "josnkey2" => "jsonvalue2"}
-  end
-
-  test_with_mock "mutilpart body file", :httpc,
-    [request: fn(_,_,_,_) ->
-      {:ok,
-       {{'HTTP/1.1', 200, 'OK'},
-        [{'connection', 'keep-alive'}, {'date', 'Sun, 18 Dec 2016 07:12:26 GMT'},
-         {'server', 'nginx'}, {'content-length', '392'},
-         {'content-type', 'application/json'}, {'access-control-allow-origin', '*'},
-         {'access-control-allow-credentials', 'true'}],
-        '{\n  "args": {}, \n  "data": "", \n  "files": {\n    "file": "#!/usr/bin/env bash\\necho \\"test multipart file\\"\\n"\n  }, \n  "form": {}, \n  "headers": {\n    "Content-Length": "279", \n    "Content-Type": "multipart/form-data; boundary=---------------------------strhhsyppielzidl", \n    "Host": "httpbin.org"\n  }, \n  "json": null, \n  "origin": "183.240.20.213", \n  "url": "http://httpbin.org/post"\n}\n'}}
-    end] do
-    conn = Client.multipart_test
-    assert get_resp_body(conn, "files") == %{"file" => "#!/usr/bin/env bash\necho \"test multipart file\"\n"}
-  end
-
-  test_with_mock "mutilpart body file extra headers", :httpc,
-    [request: fn(_,_,_,_) ->
-      {:ok,
-       {{'HTTP/1.1', 200, 'OK'},
-        [{'connection', 'keep-alive'}, {'date', 'Sun, 18 Dec 2016 07:12:55 GMT'},
-         {'server', 'nginx'}, {'content-length', '392'},
-         {'content-type', 'application/json'}, {'access-control-allow-origin', '*'},
-         {'access-control-allow-credentials', 'true'}],
-        '{\n  "args": {}, \n  "data": "", \n  "files": {\n    "file": "#!/usr/bin/env bash\\necho \\"test multipart file\\"\\n"\n  }, \n  "form": {}, \n  "headers": {\n    "Content-Length": "273", \n    "Content-Type": "multipart/form-data; boundary=---------------------------zyqgbugdbtbhzjlh", \n    "Host": "httpbin.org"\n  }, \n  "json": null, \n  "origin": "183.240.20.213", \n  "url": "http://httpbin.org/post"\n}\n'}}
-    end] do
-    conn = Client.multipart_with_extra_header_test
-    assert get_resp_body(conn, "files") == %{"file" => "#!/usr/bin/env bash\necho \"test multipart file\"\n"}
   end
 
   test_with_mock "send file without content-type", :httpc,

--- a/test/maxwell/adapter/ibrowse_test.exs
+++ b/test/maxwell/adapter/ibrowse_test.exs
@@ -64,19 +64,6 @@ defmodule Maxwell.IbrowseMockTest do
       |> Client.get
     end
 
-    def multipart_test() do
-      "/post"
-      |> new()
-      |> put_req_body({:multipart, [{:file, "test/maxwell/multipart_test_file.sh"}]})
-      |> Client.post!
-    end
-    def multipart_with_extra_header_test() do
-      "/post"
-      |> new()
-      |> put_req_body({:multipart, [{:file, "test/maxwell/multipart_test_file.sh", [{"Content-Type", "image/jpeg"}]}]})
-      |> Client.post!
-    end
-
     def file_test(filepath) do
       "/post"
       |> new()
@@ -139,34 +126,6 @@ defmodule Maxwell.IbrowseMockTest do
      end] do
     result = %{"josnkey1" => "jsonvalue1", "josnkey2" => "jsonvalue2"} |> Client.encode_decode_json_test
     assert result == %{"josnkey1" => "jsonvalue1", "josnkey2" => "jsonvalue2"}
-  end
-
-  test_with_mock "mutilpart body file", :ibrowse,
-    [send_req:
-     fn(_,_,_,_,_) ->
-       {:ok, '200',
-        [{'Server', 'nginx'}, {'Date', 'Sun, 18 Dec 2016 03:13:54 GMT'},
-         {'Content-Type', 'application/json'}, {'Content-Length', '392'},
-         {'Connection', 'keep-alive'}, {'Access-Control-Allow-Origin', '*'},
-         {'Access-Control-Allow-Credentials', 'true'}],
-        '{\n  "args": {}, \n  "data": "", \n  "files": {\n    "file": "#!/usr/bin/env bash\\necho \\"test multipart file\\"\\n"\n  }, \n  "form": {}, \n  "headers": {\n    "Content-Length": "279", \n    "Content-Type": "multipart/form-data; boundary=---------------------------hknycbtpcxdlluen", \n    "Host": "httpbin.org"\n  }, \n  "json": null, \n  "origin": "183.240.20.213", \n  "url": "http://httpbin.org/post"\n}\n'}
-     end] do
-    conn = Client.multipart_test
-    assert get_resp_body(conn, "files") == %{"file" => "#!/usr/bin/env bash\necho \"test multipart file\"\n"}
-  end
-
-  test_with_mock "mutilpart body file extra headers", :ibrowse,
-    [send_req:
-     fn(_,_,_,_,_) ->
-       {:ok, '200',
-        [{'Server', 'nginx'}, {'Date', 'Sun, 18 Dec 2016 03:15:23 GMT'},
-         {'Content-Type', 'application/json'}, {'Content-Length', '392'},
-         {'Connection', 'keep-alive'}, {'Access-Control-Allow-Origin', '*'},
-         {'Access-Control-Allow-Credentials', 'true'}],
-        '{\n  "args": {}, \n  "data": "", \n  "files": {\n    "file": "#!/usr/bin/env bash\\necho \\"test multipart file\\"\\n"\n  }, \n  "form": {}, \n  "headers": {\n    "Content-Length": "273", \n    "Content-Type": "multipart/form-data; boundary=---------------------------myyesqvzohlzgweh", \n    "Host": "httpbin.org"\n  }, \n  "json": null, \n  "origin": "183.240.20.213", \n  "url": "http://httpbin.org/post"\n}\n'}
-     end] do
-    conn = Client.multipart_with_extra_header_test
-    assert get_resp_body(conn, "files") == %{"file" => "#!/usr/bin/env bash\necho \"test multipart file\"\n"}
   end
 
   test_with_mock "send file without content-type", :ibrowse,


### PR DESCRIPTION
Following PR #71, adapters `send_multipart` callback can be refactored out.

With this refactoring there isn't any behaviour change among the `send_multipart` adapters logic.
We can just remove some duplicated code and tests without coverage decrease.
