### PR TITLE
[elixir 1.15] add prune_code_paths false

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Maxwell.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/zhongwencool/maxwell"
-  @version "2.3.1"
+  @version "2.4.0-alpha.1"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,8 @@ defmodule Maxwell.Mixfile do
       deps: deps(),
       test_coverage: [tool: ExCoveralls],
       xref: [exclude: [Poison, Maxwell.Adapter.Ibrowse]],
-      dialyzer: [plt_add_deps: true]
+      dialyzer: [plt_add_deps: true],
+      elixirc_options: [prune_code_paths: false]
     ]
   end
 


### PR DESCRIPTION
Refer to:

0. https://github.com/elixir-lang/elixir/releases/tag/v1.15.0

> Potential incompatibilities
Due to the code path pruning, if you have an application or dependency
that does not specify its dependencies on Erlang and Elixir application,
it may no longer compile successfully in Elixir v1.15. You can temporarily
disable code path pruning by setting prune_code_paths: false in your
mix.exs, although doing so may lead to runtime bugs that are only
manifested inside a mix release.

1. https://mikebian.co/learning-elixir-and-ecto/

> Elixir 1.15 makes it more challenging to check if an optional package is loaded from the parent application. [prune_code_paths: false](https://github.com/jeremyjh/dialyxir/issues/508) fixes this, but you lose all of the benefits of the Elixir 1.15 compiler. You can run mix deps.compile --force once which fixes the issue as well.

